### PR TITLE
🚸 [神器0397] 階層昇華の羽のバグ修正及び使用回数の調整

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0397.floor_sublimation_wing/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0397.floor_sublimation_wing/give/2.give.mcfunction
@@ -19,7 +19,7 @@
 # MP以外の消費物 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure CostText set value
 # 使用回数 (int) (オプション)
-    data modify storage asset:sacred_treasure RemainingCount set value 10
+    data modify storage asset:sacred_treasure RemainingCount set value 25
 # 神器を発動できるスロット (string) Wikiを参照
     data modify storage asset:sacred_treasure Slot set value "auto"
 # 神器のトリガー (string) Wikiを参照

--- a/Asset/data/asset/functions/sacred_treasure/0397.floor_sublimation_wing/trigger/2.check_condition.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0397.floor_sublimation_wing/trigger/2.check_condition.mcfunction
@@ -13,7 +13,7 @@
         scoreboard players set $397_Count Temporary 0
         scoreboard players set $397_Stat Temporary 0
     # Y <= 32ブロック に埋まることなくTPできるブロックが存在するか
-        function asset:sacred_treasure/0397.floor_sublimation_wing/trigger/2.1.check_block
+        execute positioned ~ ~1 ~ run function asset:sacred_treasure/0397.floor_sublimation_wing/trigger/2.1.check_block
         execute if score $397_Stat Temporary matches 1 as @e[type=area_effect_cloud,tag=B1.Marker,distance=..32,limit=1] at @s if predicate lib:is_ban_tp_area run scoreboard players set $397_Stat Temporary 0
         execute if score $397_Stat Temporary matches 0 if entity @s[tag=CanUsed] run function lib:message/sacred_treasure/can_not_use_here
         execute if score $397_Stat Temporary matches 0 run tag @s remove CanUsed


### PR DESCRIPTION
非フルブロック上で実行時、実行位置にテレポートしてしまうバグの修正
また、使用回数が想定した使い方では少なすぎると感じたため、修正