### PR TITLE
🐛 複数の神器の説明文/ダメージ表記等を修正

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0250.phoenix/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0250.phoenix/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:sacred_treasure AttackInfo.AttackType set value [Magic]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)
-    data modify storage asset:sacred_treasure AttackInfo.ElementType set value [Thunder]
+    data modify storage asset:sacred_treasure AttackInfo.ElementType set value [Fire]
 # 攻撃に関する情報 -防御無視 (boolean) Wikiを参照 (オプション)
     # data modify storage asset:sacred_treasure AttackInfo.BypassResist set value
 # 攻撃に関する情報 -範囲攻撃 (string) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0250.phoenix/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0250.phoenix/trigger/3.main.mcfunction
@@ -30,7 +30,7 @@
         execute at @e[type=#lib:living,type=!player,tag=Victim,tag=Hit,distance=..100,limit=1] run playsound item.firecharge.use master @a[distance=..100] ~ ~ ~ 10 1 1
         execute at @e[type=#lib:living,type=!player,tag=Victim,tag=Hit,distance=..100,limit=1] run playsound item.firecharge.use master @a[distance=..100] ~ ~ ~ 10 1 1
     # だめーーじ
-        data merge storage lib: {Argument:{Damage:60.0f,AttackType:Magic,ElementType:Thunder,BypassResist:0b}}
+        data merge storage lib: {Argument:{Damage:60.0f,AttackType:Magic,ElementType:Fire,BypassResist:0b}}
         execute if score @s Temporary matches 1 run data modify storage lib: Argument.Damage set value 50.0f
         execute if score @s Temporary matches 2 run data modify storage lib: Argument.Damage set value 55.0f
         execute if score @s Temporary matches 3 run data modify storage lib: Argument.Damage set value 60.0f

--- a/Asset/data/asset/functions/sacred_treasure/0369.fire_magic/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0369.fire_magic/give/2.give.mcfunction
@@ -15,7 +15,7 @@
 # 神器の名前 (TextComponentString)
     data modify storage asset:sacred_treasure Name set value '{"text":"ファイヤーマジック","color":"red"}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:sacred_treasure Lore set value ['{"text":"炎の術式を宿した杖。"}','{"text":"敵にやや協力な魔法火属性ダメージを与える"}']
+    data modify storage asset:sacred_treasure Lore set value ['{"text":"炎の術式を宿した杖。"}','{"text":"敵にやや強力な魔法火属性ダメージを与える"}']
 # MP以外の消費物 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure CostText set value
 # 使用回数 (int) (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0372.water_magic/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0372.water_magic/give/2.give.mcfunction
@@ -27,7 +27,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:sacred_treasure AttackInfo.Damage set value [15.2]
+    data modify storage asset:sacred_treasure AttackInfo.Damage set value ["15.2"]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:sacred_treasure AttackInfo.AttackType set value [Magic]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0372.water_magic/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0372.water_magic/give/2.give.mcfunction
@@ -27,7 +27,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:sacred_treasure AttackInfo.Damage set value ["15.2"]
+    data modify storage asset:sacred_treasure AttackInfo.Damage set value "15.2"
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:sacred_treasure AttackInfo.AttackType set value [Magic]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0373.ice_sorcery/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0373.ice_sorcery/give/2.give.mcfunction
@@ -27,7 +27,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:sacred_treasure AttackInfo.Damage set value ["20.3"]
+    data modify storage asset:sacred_treasure AttackInfo.Damage set value "20.3"
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:sacred_treasure AttackInfo.AttackType set value [Magic]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0373.ice_sorcery/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0373.ice_sorcery/give/2.give.mcfunction
@@ -27,7 +27,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:sacred_treasure AttackInfo.Damage set value [20.3]
+    data modify storage asset:sacred_treasure AttackInfo.Damage set value ["20.3"]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:sacred_treasure AttackInfo.AttackType set value [Magic]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0462.456_dice/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0462.456_dice/give/2.give.mcfunction
@@ -15,7 +15,7 @@
 # 神器の名前 (TextComponentString)
     data modify storage asset:sacred_treasure Name set value '{"text":"4・5・6ダイス","color":"yellow"}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:sacred_treasure Lore set value ['{"text":"出目が4・5・6のみのサイコロ"}','[{"text":"振ることで近くの敵1体に"},{"text":"火 ","color":"red"},{"text":"水 ","color":"aqua"},{"text":"雷","color":"yellow"},{"text":"の属性から","color":"white"}]','{"text":"ランダムな属性の出た目 * 5ダメージを与える"}']
+    data modify storage asset:sacred_treasure Lore set value ['{"text":"出目が4・5・6のみのサイコロ"}','[{"text":"振ることで近くの敵1体に"},{"text":"火 ","color":"red"},{"text":"水 ","color":"aqua"},{"text":"雷","color":"yellow"},{"text":"の属性から","color":"white"}]','{"text":"ランダムな属性の出た目 * 7ダメージを与える"}']
 # MP以外の消費物 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure CostText set value
 # 使用回数 (int) (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0630.ice_leggings/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0630.ice_leggings/give/2.give.mcfunction
@@ -51,7 +51,7 @@
 # 扱える神 (string[]) Wikiを参照
     data modify storage asset:sacred_treasure CanUsedGod set value ['Flora', 'Urban', 'Wi-ki', 'Rumor']
 # カスタムNBT (NBTCompound) 追加で指定したいNBT (オプション)
-    data modify storage asset:sacred_treasure CustomNBT set value {HideFlags:68,display:{color:7274495},Unbreakable:1b,AttributeModifiers:[{AttributeName:"generic.armor",Name:"generic.armor",Amount:5,Operation:0,UUID:[I;1,1,630,4],Slot:"legs"},{AttributeName:"generic.armor_toughness",Name:"generic.armor_toughness",Amount:1,Operation:0,UUID:[I;1,1,630,4],Slot:"chest"}]}
+    data modify storage asset:sacred_treasure CustomNBT set value {HideFlags:68,display:{color:7274495},Unbreakable:1b,AttributeModifiers:[{AttributeName:"generic.armor",Name:"generic.armor",Amount:5,Operation:0,UUID:[I;1,1,630,4],Slot:"legs"},{AttributeName:"generic.armor_toughness",Name:"generic.armor_toughness",Amount:1,Operation:0,UUID:[I;1,1,630,4],Slot:"legs"}]}
 
 
 # 神器の入手用function


### PR DESCRIPTION
フェニックスが名前と攻撃属性が合わないのを修正
ウォーターマジック、アイスソーサリーのダメージ表記を修正
456ダイス、lore修正
アイスレギンス、防御の部位が違うのを修正