### PR TITLE
🚸 [神器0218] アイアンストームを上方修正

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 攻撃に関する情報 (オプション)
     data modify storage asset:sacred_treasure AttackInfo set value {Damage:"???",AttackType:[Physical],ElementType:[None],BypassResist:0b}
 # MP消費量 (int)
-    data modify storage asset:sacred_treasure MPCost set value 250
+    data modify storage asset:sacred_treasure MPCost set value 120
 # MP必要量 (int) (オプション)
     # data modify storage asset:sacred_treasure MPRequire set value
 # 神器のクールダウン (int) (オプション)

--- a/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/0.load.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/0.load.mcfunction
@@ -1,0 +1,9 @@
+#> asset:sacred_treasure/0218.iron_storm/trigger/0.load
+#
+# 神器に利用するスコアボード等の初期化処理
+#
+# @within tag/function asset:sacred_treasure/load
+
+#> 定義類はここに
+# @within function asset:sacred_treasure/0218.iron_storm/trigger/**
+    scoreboard objectives add DA.OwnerID dummy

--- a/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/3.3.blast.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/3.3.blast.mcfunction
@@ -9,6 +9,12 @@
 # @private
     #declare score_holder $70
     #declare score_holder $DamageCoefficient
+    #declare score_holder $DA.OwnerID
+    #declare tag DA.Owner
+
+# 実行者取得
+    scoreboard players operation $DA.OwnerID Temporary = @s DA.OwnerID
+    execute as @a if score @s UserID = $DA.OwnerID Temporary run tag @s add DA.Owner
 
 # ダメージ係数計算(最大ダメージの30%~100%),計算結果: 係数[%]
     execute store result score $DamageCoefficient Temporary run function lib:random/
@@ -18,12 +24,15 @@
 # 敵へのダメージ(最大500)
     execute store result storage lib: Argument.Damage float 5 run scoreboard players get $DamageCoefficient Temporary
     data modify storage lib: Argument.AttackType set value "Physical"
+    execute as @p[tag=DA.Owner] run function lib:damage/modifier
     execute as @e[type=#lib:living,tag=!Friend,distance=..5] run function lib:damage/
     data remove storage lib: Argument
 
 # 味方へのダメージ(最大100)
     execute store result storage lib: Argument.Damage float 1 run scoreboard players get $DamageCoefficient Temporary
     data modify storage lib: Argument.AttackType set value "Physical"
+    data modify storage lib: Argument.DeathMessage set value ['[{"translate": "%1$sは鉄の雨に巻き込まれた。","with":[{"selector":"@s"}]}]']
+    execute as @p[tag=DA.Owner] run function lib:damage/modifier
     execute as @e[type=#lib:living,tag=Friend,distance=..5] run function lib:damage/
     data remove storage lib: Argument
 
@@ -35,3 +44,8 @@
 
 # 空中判定タグ削除
     tag @s remove DA.InAir
+
+# reset
+    scoreboard players reset $DA.OwnerID Temporary
+    scoreboard players reset $DamageCoefficient Temporary
+    tag @a[tag=DA.Owner] remove DA.Owner

--- a/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/3.3.blast.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/3.3.blast.mcfunction
@@ -7,21 +7,24 @@
 #> private
 #
 # @private
-    #declare score_holder $BlastDamage
     #declare score_holder $70
     #declare score_holder $DamageCoefficient
 
-# ダメージ計算(アイアンゴーレムのHPの30%~100%),計算結果=ダメージ*100
+# ダメージ係数計算(最大ダメージの30%~100%),計算結果: 係数[%]
     execute store result score $DamageCoefficient Temporary run function lib:random/
     scoreboard players operation $DamageCoefficient Temporary %= $70 Const
     scoreboard players add $DamageCoefficient Temporary 30
-    execute store result score $BlastDamage Temporary run data get entity @s AbsorptionAmount
-    scoreboard players operation $BlastDamage Temporary *= $DamageCoefficient Temporary
 
-# ダメージ
-    execute store result storage lib: Argument.Damage float 0.01 run scoreboard players get $BlastDamage Temporary
+# 敵へのダメージ(最大500)
+    execute store result storage lib: Argument.Damage float 5 run scoreboard players get $DamageCoefficient Temporary
     data modify storage lib: Argument.AttackType set value "Physical"
-    execute as @e[type=#lib:living,distance=..5] run function lib:damage/
+    execute as @e[type=#lib:living,tag=!Friend,distance=..5] run function lib:damage/
+    data remove storage lib: Argument
+
+# 味方へのダメージ(最大100)
+    execute store result storage lib: Argument.Damage float 1 run scoreboard players get $DamageCoefficient Temporary
+    data modify storage lib: Argument.AttackType set value "Physical"
+    execute as @e[type=#lib:living,tag=Friend,distance=..5] run function lib:damage/
     data remove storage lib: Argument
 
 # 音

--- a/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0218.iron_storm/trigger/3.main.mcfunction
@@ -35,6 +35,9 @@
     summon iron_golem 0 0 0 {Tags:["IronStormInit","DA.Number8","DA.InAir","Friend"],OnGround:0b}
     summon iron_golem 0 0 0 {Tags:["IronStormInit","DA.Number9","DA.InAir","Friend"],OnGround:0b}
 
+# アイアンゴーレムに使用者のID保存
+    scoreboard players operation @e[type=iron_golem,tag=IronStormInit,distance=..1,x=0,y=0,z=0] DA.OwnerID = @s UserID
+
 # アイアンゴーレム拡散
     execute rotated ~ 0 positioned ^ ^ ^40 run spreadplayers ~ ~ 0 15 false @e[type=iron_golem,tag=IronStormInit,distance=..1,x=0,y=0,z=0]
 

--- a/Asset/data/asset/tags/functions/sacred_treasure/load.json
+++ b/Asset/data/asset/tags/functions/sacred_treasure/load.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:sacred_treasure/0218.iron_storm/trigger/0.load",
         "asset:sacred_treasure/0105.secret_meat/trigger/0.load",
         "asset:sacred_treasure/0002.blessing/trigger/0.load",
         "asset:sacred_treasure/0152.call_cat/trigger/0.load",


### PR DESCRIPTION
あまりにも性能が低かったので以下の点修正
・消費MPを120にした
・敵モブへのダメージのみ今までの5倍にした
・modifierが乗るようにした