### PR TITLE
:bug: #lib:allに1.18のアイテムが含まれていないのを修正

### DIFF
--- a/TheSkyBlessing/data/lib/tags/items/all.json
+++ b/TheSkyBlessing/data/lib/tags/items/all.json
@@ -639,6 +639,7 @@
         "minecraft:music_disc_far",
         "minecraft:music_disc_mall",
         "minecraft:music_disc_mellohi",
+        "minecraft:music_disc_otherside",
         "minecraft:music_disc_pigstep",
         "minecraft:music_disc_stal",
         "minecraft:music_disc_strad",


### PR DESCRIPTION
Fix #838