### PR TITLE
:children_crossing: インベントリが満タンで落ちた神器に発光をつけ消えなくする

### DIFF
--- a/TheSkyBlessing/data/asset/functions/sacred_treasure/common/give.mcfunction
+++ b/TheSkyBlessing/data/asset/functions/sacred_treasure/common/give.mcfunction
@@ -43,6 +43,7 @@
     execute unless data storage asset:context {Type:"drop"} run function api:inventory/get_size
     execute unless data storage asset:context {Type:"drop"} if score $InvSize Lib matches ..35 run loot give @s mine 10000 0 10000 debug_stick
     execute unless data storage asset:context {Type:"drop"} if score $InvSize Lib matches 36.. run loot spawn ~ ~ ~ mine 10000 0 10000 debug_stick
+    execute unless data storage asset:context {Type:"drop"} if score $InvSize Lib matches 36.. as @e[type=item,nbt={Item:{tag:{TSB:{}}}},distance=..0.3] run data merge entity @s {Glowing:1b,Age:-32768}
 # リセット
     scoreboard players reset $InvSize Lib
     data remove storage asset:sacred_treasure ID


### PR DESCRIPTION
Fixes #691