### PR TITLE
🚸 神器の属性補正のOperationに一貫性を

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0431.weather_lock_cane/trigger/4.weather_effect.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0431.weather_lock_cane/trigger/4.weather_effect.mcfunction
@@ -9,7 +9,7 @@
 # 補正値
     data modify storage api: Argument.UUID set value [I;1,1,624,6]
     data modify storage api: Argument.Amount set value 0.4
-    data modify storage api: Argument.Operation set value "multiply_base"
+    data modify storage api: Argument.Operation set value "multiply"
 
 # 各天候により属性補正を分岐する
     execute if data storage asset:temp BZ{Weather:Sunny} run function api:player_modifier/attack/fire/add

--- a/Asset/data/asset/functions/sacred_treasure/0907.rod_of_rain/trigger/rain_cloud/04.effect.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0907.rod_of_rain/trigger/rain_cloud/04.effect.mcfunction
@@ -36,7 +36,7 @@
 
     # 体力回復量補正に水攻撃補正を掛ける
         data modify storage api: Argument.UUID set value [I;1,1,907,0]
-        data modify storage api: Argument.Operation set value "multiply_base"
+        data modify storage api: Argument.Operation set value "multiply"
         execute as @p[tag=P8.Owner] run function api:player_modifier/heal/add
 
     # 範囲内のプレイヤーを回復

--- a/Asset/data/asset/functions/sacred_treasure/0930.z_flag/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0930.z_flag/trigger/3.main.mcfunction
@@ -11,13 +11,13 @@
 # 補正の追加(物理ダメージが25%上昇する)
     data modify storage api: Argument.UUID set value [I;1,1,930,7]
     data modify storage api: Argument.Amount set value 0.25
-    data modify storage api: Argument.Operation set value "multiply"
+    data modify storage api: Argument.Operation set value "multiply_base"
     execute if entity @s[tag=!PU.Modifier] run function api:player_modifier/attack/physical/add
 
 # 補正の追加(防御が25%減少する)
     data modify storage api: Argument.UUID set value [I;1,1,930,7]
     data modify storage api: Argument.Amount set value -0.35
-    data modify storage api: Argument.Operation set value "multiply"
+    data modify storage api: Argument.Operation set value "multiply_base"
     execute if entity @s[tag=!PU.Modifier] run function api:player_modifier/defense/base/add
 
 # APIの引数が残ったままfunctionを抜けるの防止用

--- a/Asset/data/asset/functions/sacred_treasure/0952.lunatic_rod/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0952.lunatic_rod/trigger/3.main.mcfunction
@@ -34,7 +34,7 @@
 # 魔法攻撃バフ
     data modify storage api: Argument.UUID set value [I;1,1,952,0]
     data modify storage api: Argument.Amount set value 0.3
-    data modify storage api: Argument.Operation set value "multiply_base"
+    data modify storage api: Argument.Operation set value "multiply"
     function api:player_modifier/attack/magic/add
 
 # 効果時間設定


### PR DESCRIPTION
大体の防具は既にbaseだったし、大体のバフ系は既にmultiplyでした。
あんまりなおすところなかった。