### PR TITLE
🚸 [神器0898,0960-0961] 速さに関連する神器を調整

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0898.gale_pendant/register.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0898.gale_pendant/register.mcfunction
@@ -4,4 +4,4 @@
 #
 # @within tag/function asset:sacred_treasure/register
 
-data modify storage asset:sacred_treasure RarityRegistry[2] append value 898
+data modify storage asset:sacred_treasure RarityRegistry[3] append value 898

--- a/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/register.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/register.mcfunction
@@ -1,0 +1,7 @@
+#> asset:sacred_treasure/0960.heavy_charm/register
+#
+# 神器プールへの登録処理
+#
+# @within tag/function asset:sacred_treasure/register
+
+data modify storage asset:sacred_treasure RarityRegistry[1] append value 960

--- a/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/trigger/3.main.mcfunction
@@ -8,7 +8,7 @@
     function asset:sacred_treasure/common/use/hotbar
 
 # ここから先は神器側の効果の処理を書く
-    playsound minecraft:block.anvil.place player @a ~ ~ ~ 1 2
+    playsound ogg:block.smithing_table.smithing_table2 player @a ~ ~ ~ 1 1
     playsound minecraft:item.armor.equip_iron player @a ~ ~ ~ 1 1
     particle crit ~ ~1 ~ 0 0 0 0.5 10
 

--- a/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/trigger/add_modifier.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/trigger/add_modifier.mcfunction
@@ -15,31 +15,31 @@
     execute store result score $Count Temporary if data storage asset:context New.Items.hotbar[{tag:{TSB:{ID:960}}}]
 # 防御が上がるが重くなる
     execute if score $Count Temporary matches 1 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 2 add
-    execute if score $Count Temporary matches 1 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.01 add
+    execute if score $Count Temporary matches 1 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.02 add
 
     execute if score $Count Temporary matches 2 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 4 add
-    execute if score $Count Temporary matches 2 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.02 add
+    execute if score $Count Temporary matches 2 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.04 add
 
     execute if score $Count Temporary matches 3 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 6 add
-    execute if score $Count Temporary matches 3 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.03 add
+    execute if score $Count Temporary matches 3 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.06 add
 
     execute if score $Count Temporary matches 4 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 8 add
-    execute if score $Count Temporary matches 4 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.04 add
+    execute if score $Count Temporary matches 4 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.08 add
 
     execute if score $Count Temporary matches 5 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 10 add
-    execute if score $Count Temporary matches 5 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.05 add
+    execute if score $Count Temporary matches 5 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.1 add
 
     execute if score $Count Temporary matches 6 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 12 add
-    execute if score $Count Temporary matches 6 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.06 add
+    execute if score $Count Temporary matches 6 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.12 add
 
     execute if score $Count Temporary matches 7 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 14 add
-    execute if score $Count Temporary matches 7 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.07 add
+    execute if score $Count Temporary matches 7 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.14 add
 
     execute if score $Count Temporary matches 8 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 16 add
-    execute if score $Count Temporary matches 8 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.08 add
+    execute if score $Count Temporary matches 8 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.16 add
 
     execute if score $Count Temporary matches 9 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-3c000000007 "960" 18 add
-    execute if score $Count Temporary matches 9 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.09 add
+    execute if score $Count Temporary matches 9 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-3c000000007 "960" -0.18 add
 
 # リセット
     scoreboard players reset $Count Temporary

--- a/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/trigger/dis_equip/main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0960.heavy_charm/trigger/dis_equip/main.mcfunction
@@ -4,6 +4,9 @@
 #
 # @within function asset:sacred_treasure/0960.heavy_charm/trigger/dis_equip/
 
+# 音
+    playsound minecraft:item.armor.equip_generic player @a ~ ~ ~ 1 0.8
+
 # 補正を削除
     attribute @s minecraft:generic.armor modifier remove 1-0-1-0-3c000000007
     attribute @s minecraft:generic.movement_speed modifier remove 1-0-1-0-3c000000007

--- a/Asset/data/asset/functions/sacred_treasure/0961.light_charm/register.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0961.light_charm/register.mcfunction
@@ -1,0 +1,7 @@
+#> asset:sacred_treasure/0961.light_charm/register
+#
+# 神器プールへの登録処理
+#
+# @within tag/function asset:sacred_treasure/register
+
+data modify storage asset:sacred_treasure RarityRegistry[1] append value 961

--- a/Asset/data/asset/functions/sacred_treasure/0961.light_charm/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0961.light_charm/trigger/3.main.mcfunction
@@ -8,8 +8,8 @@
     function asset:sacred_treasure/common/use/hotbar
 
 # ここから先は神器側の効果の処理を書く
-    playsound minecraft:block.anvil.place player @a ~ ~ ~ 1 1.5
-    playsound minecraft:entity.player.attack.sweep player @a ~ ~ ~ 1 1.5
+    playsound ogg:block.smithing_table.smithing_table2 player @a ~ ~ ~ 1 1.6
+    playsound minecraft:item.armor.equip_iron player @a ~ ~ ~ 1 1
     particle crit ~ ~1 ~ 0 0 0 0.5 10
 
 # 補正を追加

--- a/Asset/data/asset/functions/sacred_treasure/0961.light_charm/trigger/add_modifier.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0961.light_charm/trigger/add_modifier.mcfunction
@@ -12,31 +12,31 @@
     execute store result score $Count Temporary if data storage asset:context New.Items.hotbar[{tag:{TSB:{ID:961}}}]
 # 防御が上がるが重くなる
     execute if score $Count Temporary matches 1 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -1 add
-    execute if score $Count Temporary matches 1 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.005 add
+    execute if score $Count Temporary matches 1 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.015 add
 
     execute if score $Count Temporary matches 2 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -2 add
-    execute if score $Count Temporary matches 2 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.01 add
+    execute if score $Count Temporary matches 2 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.03 add
 
     execute if score $Count Temporary matches 3 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -3 add
-    execute if score $Count Temporary matches 3 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.015 add
+    execute if score $Count Temporary matches 3 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.045 add
 
     execute if score $Count Temporary matches 4 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -4 add
-    execute if score $Count Temporary matches 4 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.02 add
+    execute if score $Count Temporary matches 4 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.06 add
 
     execute if score $Count Temporary matches 5 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -5 add
-    execute if score $Count Temporary matches 5 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.025 add
+    execute if score $Count Temporary matches 5 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.075 add
 
     execute if score $Count Temporary matches 6 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -6 add
-    execute if score $Count Temporary matches 6 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.03 add
+    execute if score $Count Temporary matches 6 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.09 add
 
     execute if score $Count Temporary matches 7 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -7 add
-    execute if score $Count Temporary matches 7 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.035 add
+    execute if score $Count Temporary matches 7 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.105 add
 
     execute if score $Count Temporary matches 8 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -8 add
-    execute if score $Count Temporary matches 8 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.04 add
+    execute if score $Count Temporary matches 8 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.13 add
 
     execute if score $Count Temporary matches 9 run attribute @s minecraft:generic.armor modifier add 1-0-1-0-03c100000007 "961" -9 add
-    execute if score $Count Temporary matches 9 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.045 add
+    execute if score $Count Temporary matches 9 run attribute @s minecraft:generic.movement_speed modifier add 1-0-1-0-03c100000007 "961" 0.145 add
 
 # リセット
     scoreboard players reset $Count Temporary

--- a/Asset/data/asset/functions/sacred_treasure/0961.light_charm/trigger/dis_equip/main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0961.light_charm/trigger/dis_equip/main.mcfunction
@@ -4,6 +4,9 @@
 #
 # @within function asset:sacred_treasure/0961.light_charm/trigger/dis_equip/
 
+# 音
+    playsound minecraft:item.armor.equip_generic player @a ~ ~ ~ 1 0.8
+
 # 補正を削除
     attribute @s minecraft:generic.armor modifier remove 1-0-1-0-03c100000007
     attribute @s minecraft:generic.movement_speed modifier remove 1-0-1-0-03c100000007

--- a/Asset/data/asset/tags/functions/sacred_treasure/register.json
+++ b/Asset/data/asset/tags/functions/sacred_treasure/register.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:sacred_treasure/0961.light_charm/register",
         "asset:sacred_treasure/0980.thunder_charm/register",
         "asset:sacred_treasure/0979.water_charm/register",
         "asset:sacred_treasure/0978.fire_charm/register",

--- a/Asset/data/asset/tags/functions/sacred_treasure/register.json
+++ b/Asset/data/asset/tags/functions/sacred_treasure/register.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:sacred_treasure/0960.heavy_charm/register",
         "asset:sacred_treasure/0961.light_charm/register",
         "asset:sacred_treasure/0980.thunder_charm/register",
         "asset:sacred_treasure/0979.water_charm/register",


### PR DESCRIPTION
・疾風のペンダントはランク3行き
・軽装、重装チャームの速度上昇、減少が更にデカく
・軽装、重装チャームにそもそもレアリティ設定されてなかったので設定