### PR TITLE
🐛 [神器0233] 大逆転が動作しない問題を修正

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0233.reversal/trigger/set_mp.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0233.reversal/trigger/set_mp.mcfunction
@@ -6,5 +6,5 @@
 execute store result score $6H.MP Temporary run function lib:mp/get
 execute store result score $6H.SetMP Temporary run function lib:mp/get_max
 scoreboard players operation $6H.SetMP Temporary -= $6H.MP Temporary
-execute store result score $Set Lib run scoreboard players get $6H.MP Temporary
+execute store result score $Set Lib run scoreboard players get $6H.SetMP Temporary
 function lib:mp/set


### PR DESCRIPTION
計算時の取得スコアが間違っていました。
作っていた時はHP30%を取得する処理で精一杯でした