### PR TITLE
🚸 [神器0976] ブレイブソードのMPコストを調整

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0976.brave_sword/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0976.brave_sword/give/2.give.mcfunction
@@ -39,7 +39,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:sacred_treasure Condition set value
 # MP消費量 (int)
-    data modify storage asset:sacred_treasure MPCost set value 8
+    data modify storage asset:sacred_treasure MPCost set value 10
 # MP必要量 (int) (オプション)
 #    data modify storage asset:sacred_treasure MPRequire set value 100
 # 神器のクールダウン (int) (オプション)


### PR DESCRIPTION
8だとコスパが良すぎるらしい。