### PR TITLE
⚖️ ストンパー系モブが無敵時間無視の踏みつけを繰り出すように

### DIFF
--- a/Asset/data/asset/functions/mob/0287.burning_stomper/tick/event/stomp.mcfunction
+++ b/Asset/data/asset/functions/mob/0287.burning_stomper/tick/event/stomp.mcfunction
@@ -22,7 +22,7 @@
     function lib:damage/modifier
 
 # ダメージを与える
-    execute if data storage api: {HurtTime:0s} as @a[gamemode=!spectator,gamemode=!creative,distance=..3] run function lib:damage/
+    execute as @a[gamemode=!spectator,gamemode=!creative,distance=..3] run function lib:damage/
 
 # 吹き飛ばし
     execute at @a[gamemode=!spectator,distance=..3] run summon area_effect_cloud ~ ~ ~ {Radius:0.1f,Duration:6,Age:4,Effects:[{Id:25,Amplifier:20b,Duration:7,ShowParticles:0b}]}

--- a/Asset/data/asset/functions/mob/0292.trample_bot/tick/event/stomp.mcfunction
+++ b/Asset/data/asset/functions/mob/0292.trample_bot/tick/event/stomp.mcfunction
@@ -22,7 +22,7 @@
     function lib:damage/modifier
 
 # ダメージを与える
-    execute if data storage api: {HurtTime:0s} as @a[gamemode=!spectator,gamemode=!creative,distance=..2] run function lib:damage/
+    execute as @a[gamemode=!spectator,gamemode=!creative,distance=..2] run function lib:damage/
 
 # 吹き飛ばし
     execute at @a[gamemode=!spectator,distance=..2] run summon area_effect_cloud ~ ~ ~ {Radius:0.1f,Duration:6,Age:4,Effects:[{Id:25,Amplifier:20b,Duration:5,ShowParticles:0b}]}


### PR DESCRIPTION
api取得してないせいでダメージ与えられてない問題の修正でもあります。
どういうわけかデバッグ環境ではapiが残ったままだったので気づけなかったようです。