### PR TITLE
🐛 LibraryDamageタグが削除されないのを修正

### DIFF
--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacked_entity/on_attack.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacked_entity/on_attack.mcfunction
@@ -7,7 +7,7 @@
 # tag付け
     tag @s add this
 # フィルタ
-    execute as @e[type=#lib:living,type=!player,nbt=!{HurtTime:0s},distance=..150] run function mob_manager:entity_finder/attacked_entity/filters/15
+    execute unless entity @e[type=#lib:living,type=!player,tag=LibraryDamage,distance=..150,limit=1] as @e[type=#lib:living,type=!player,nbt=!{HurtTime:0s},distance=..150] run function mob_manager:entity_finder/attacked_entity/filters/15
     execute as @e[type=#lib:living,type=!player,tag=LibraryDamage,distance=..150] run function mob_manager:entity_finder/attacked_entity/filters/15
 # リセット
     tag @s remove LibraryDamage

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/on_hurt.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/on_hurt.mcfunction
@@ -10,4 +10,5 @@
     execute unless entity @e[type=#lib:living,type=!player,tag=LibraryDamage,distance=..150,limit=1] as @e[type=#lib:living,type=!player,distance=..150] run function mob_manager:entity_finder/attacking_entity/filters/15
     execute as @e[type=#lib:living,type=!player,tag=LibraryDamage,distance=..150] run function mob_manager:entity_finder/attacking_entity/filters/15
 # リセット
+    tag @s remove LibraryDamage
     advancement revoke @s only mob_manager:entity_finder/check_attacking_entity


### PR DESCRIPTION
おまけで軽量化Commitが混ざってます

後動作テストはreviewerに任せた
Fix #1115, Fix #1108