### PR TITLE
:bug: player_modifier/*/removeが間違った値を返すことがあるのを修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/player_modifier/core/attack/base/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/attack/base/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Attack.Base
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/attack/fire/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/attack/fire/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Attack.Fire
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/attack/magic/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/attack/magic/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Attack.Magic
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/attack/physical/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/attack/physical/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Attack.Physical
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/attack/thunder/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/attack/thunder/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Attack.Thunder
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/attack/water/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/attack/water/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Attack.Water
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/defense/base/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/defense/base/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Defense.Base
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 削除されたデータの加工

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/defense/fire/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/defense/fire/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Defense.Fire
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 削除されたデータの加工

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/defense/magic/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/defense/magic/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Defense.Magic
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 削除されたデータの加工

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/defense/physical/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/defense/physical/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Defense.Physical
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 削除されたデータの加工

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/defense/thunder/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/defense/thunder/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Defense.Thunder
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 削除されたデータの加工

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/defense/water/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/defense/water/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Defense.Water
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 削除されたデータの加工

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/heal/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/heal/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.Heal
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す

--- a/TheSkyBlessing/data/api/functions/player_modifier/core/mp_regen/remove.mcfunction
+++ b/TheSkyBlessing/data/api/functions/player_modifier/core/mp_regen/remove.mcfunction
@@ -10,6 +10,7 @@
     data modify storage api: Modifiers set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Modifier.MPRegen
 # 配列の初期化
     data modify storage api: NewModifiers set value []
+    data remove storage api: Removed
 # フィルタ
     function api:player_modifier/core/common/remove_modifier
 # 新しい配列を戻す


### PR DESCRIPTION
引数のUUIDに該当するModifierが無いときに前の値を返すバグ