### PR TITLE
:children_crossing: テレポーター以外の各種テレポート先をforceloadする

### DIFF
--- a/TheSkyBlessing/data/core/functions/load_once.mcfunction
+++ b/TheSkyBlessing/data/core/functions/load_once.mcfunction
@@ -18,7 +18,19 @@ data modify storage global GameVersion set value "v0.1.4"
     execute in the_end run forceload add 10000 10000
 # Item Return Point
     execute in overworld run forceload add 2927 -1273
-
+# テレポート先
+    # 神殿出口
+        execute in overworld run forceload add 62 -12
+    # 神殿入り口
+        execute in overworld run forceload add 3040 -544 3103 -481
+    # Item Return Point
+        execute in overworld run forceload add 2922 -1333 2934 -1313
+    # 神殿
+        execute in overworld run forceload add 2976 -144 3007 -129
+        execute in overworld run forceload add 3448 -472
+        execute in overworld run forceload add 2915 -862
+        execute in overworld run forceload add 3056 -896 3087 -881
+        execute in overworld run forceload add 3411 -630
 
 #> gameruleの設定
 function core:define_gamerule

--- a/TheSkyBlessing/data/core/functions/migration/v0.1.4/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/migration/v0.1.4/.mcfunction
@@ -19,3 +19,13 @@ data modify storage global GodIcon.Urban set value '{"text":"\\uE011","color":"w
 data modify storage global GodIcon.Nyaptov set value '{"text":"\\uE012","color":"white","font":"tsb"}'
 data modify storage global GodIcon.Wi-ki set value '{"text":"\\uE013","color":"white","font":"tsb"}'
 data modify storage global GodIcon.Rumor set value '{"text":"\\uE014","color":"white","font":"tsb"}'
+
+#> from: 61c9ba4adb1482b9f000fa66ad3f4669dec0e840
+execute in overworld run forceload add 62 -12
+execute in overworld run forceload add 3040 -544 3103 -481
+execute in overworld run forceload add 2922 -1333 2934 -1313
+execute in overworld run forceload add 2976 -144 3007 -129
+execute in overworld run forceload add 3448 -472
+execute in overworld run forceload add 2915 -862
+execute in overworld run forceload add 3056 -896 3087 -881
+execute in overworld run forceload add 3411 -630


### PR DESCRIPTION
エンドゲート、チャンクが読み込まれてからクライアント側が飛ぶのでめっちゃラグく見えてめっちゃ気になった