### PR TITLE
🐛 ダメージ対象判定用タグが消えない問題を修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_on_attack.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_on_attack.mcfunction
@@ -48,3 +48,4 @@
     execute if entity @s[tag=FindFlag15.1] run advancement grant @a[tag=TargetAttacker] only mob_manager:entity_finder/check_attacked_entity 15-1
 # リセット
     tag @a[tag=TargetAttacker] remove TargetAttacker
+    tag @s remove VictimFromLibrary

--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_on_damage/as_attacker.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_on_damage/as_attacker.mcfunction
@@ -5,7 +5,7 @@
 # @within function api:damage/core/trigger_on_damage/
 
 # 特定用タグ
-    tag @s add AttckerFromLibrary
+    tag @s add AttackerFromLibrary
 # トリガー
     execute if entity @s[tag=FindFlag0.0] run advancement grant @a[tag=TargetAttacker] only mob_manager:entity_finder/check_attacking_entity 0-0
     execute if entity @s[tag=FindFlag0.1] run advancement grant @a[tag=TargetAttacker] only mob_manager:entity_finder/check_attacking_entity 0-1
@@ -41,4 +41,4 @@
     execute if entity @s[tag=FindFlag15.1] run advancement grant @a[tag=TargetAttacker] only mob_manager:entity_finder/check_attacking_entity 15-1
 # リセット
     tag @s remove TargetAttacker
-    tag @s remove AttckerFromLibrary
+    tag @s remove AttackerFromLibrary

--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_on_damage/as_attacker.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_on_damage/as_attacker.mcfunction
@@ -41,3 +41,4 @@
     execute if entity @s[tag=FindFlag15.1] run advancement grant @a[tag=TargetAttacker] only mob_manager:entity_finder/check_attacking_entity 15-1
 # リセット
     tag @s remove TargetAttacker
+    tag @s remove AttckerFromLibrary

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacked_entity/_index.d.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacked_entity/_index.d.mcfunction
@@ -17,6 +17,5 @@
 #> lib:damage/からの攻撃検出用
 # @within function
 #   mob_manager:entity_finder/attacked_entity/on_attack
-#   mob_manager:entity_finder/attacked_entity/fetch_attacked_entity
 #   api:damage/core/trigger_on_attack
     #declare tag VictimFromLibrary

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacked_entity/fetch_attacked_entity.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacked_entity/fetch_attacked_entity.mcfunction
@@ -9,5 +9,3 @@
 # 紐づけ用スコア
     scoreboard players operation @s AttackedEntity = @p[tag=TargetEntity] UserID
     scoreboard players operation @p[tag=TargetEntity] AttackedEntity = @p[tag=TargetEntity] UserID
-# リセット
-    tag @s remove VictimFromLibrary

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/_index.d.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/_index.d.mcfunction
@@ -18,4 +18,4 @@
 # @within function
 #   mob_manager:entity_finder/attacking_entity/on_hurt
 #   api:damage/core/trigger_on_damage/as_attacker
-    #declare tag AttckerFromLibrary
+    #declare tag AttackerFromLibrary

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/_index.d.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/_index.d.mcfunction
@@ -17,6 +17,5 @@
 #> lib:damage/からの攻撃検出用
 # @within function
 #   mob_manager:entity_finder/attacking_entity/on_hurt
-#   mob_manager:entity_finder/attacking_entity/fetch_attacking_entity
 #   api:damage/core/trigger_on_damage/as_attacker
     #declare tag AttckerFromLibrary

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/fetch_attacking_entity.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/fetch_attacking_entity.mcfunction
@@ -9,5 +9,3 @@
 # 紐づけ用スコア
     scoreboard players operation @s AttackingEntity = @p[tag=TargetEntity] UserID
     scoreboard players operation @p[tag=TargetEntity] AttackingEntity = @p[tag=TargetEntity] UserID
-# リセット
-    tag @s remove AttckerFromLibrary

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/on_hurt.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/attacking_entity/on_hurt.mcfunction
@@ -7,8 +7,8 @@
 # tag付け
     tag @s add TargetEntity
 # フィルタ
-    execute unless entity @e[type=#lib:living,type=!player,tag=AttckerFromLibrary,distance=..150,limit=1] as @e[type=#lib:living,type=!player,distance=..150] run function mob_manager:entity_finder/attacking_entity/filters/15
-    execute as @e[type=#lib:living,type=!player,tag=AttckerFromLibrary,distance=..150] run function mob_manager:entity_finder/attacking_entity/filters/15
+    execute unless entity @e[type=#lib:living,type=!player,tag=AttackerFromLibrary,distance=..150,limit=1] as @e[type=#lib:living,type=!player,distance=..150] run function mob_manager:entity_finder/attacking_entity/filters/15
+    execute as @e[type=#lib:living,type=!player,tag=AttackerFromLibrary,distance=..150] run function mob_manager:entity_finder/attacking_entity/filters/15
 # リセット
     tag @s remove TargetEntity
     advancement revoke @s only mob_manager:entity_finder/check_attacking_entity


### PR DESCRIPTION
AttckerFromLibraryじゃなくてAttackerFromLibraryに語字修正するべきなんだけどこのプルリクで修正するか悩んでます
追記：advancementの実行のほうが早いのでadvancementからタグ消すことが出来ません。そういう意図の修正です