### PR TITLE
:truck: HealAPIをlib:からapi:に移動する

### DIFF
--- a/TheSkyBlessing/data/api/functions/heal/.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/.mcfunction
@@ -5,7 +5,7 @@
 # 実行者はHealthを持つEntityである必要があります。
 #
 # @input
-#   as player
+#   as living entity
 #   storage api: Argument.Heal : float
 #   storage api: Argument.FixedHeal? : boolean(default: false)
 # @api

--- a/TheSkyBlessing/data/api/functions/heal/.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/.mcfunction
@@ -6,12 +6,12 @@
 #
 # @input
 #   as player
-#   storage lib: Argument.Heal : float
-#   storage lib: Argument.FixedHeal? : boolean(default: false)
+#   storage api: Argument.Heal : float
+#   storage api: Argument.FixedHeal? : boolean(default: false)
 # @api
 
 # 引数チェック
-    execute unless data storage lib: Argument.Heal run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"引数が足りません","color":"white"},{"text":" Heal","color":"red"}]
+    execute unless data storage api: Argument.Heal run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"引数が足りません","color":"white"},{"text":" Heal","color":"red"}]
 # プレイヤー
     execute if entity @s[type=player] run function api:heal/core/player
 # non-プレイヤー

--- a/TheSkyBlessing/data/api/functions/heal/.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/.mcfunction
@@ -1,0 +1,18 @@
+#> api:heal/
+#
+# 実行者のエンティティを回復させます。
+#
+# 実行者はHealthを持つEntityである必要があります。
+#
+# @input
+#   as player
+#   storage lib: Argument.Heal : float
+#   storage lib: Argument.FixedHeal? : boolean(default: false)
+# @api
+
+# 引数チェック
+    execute unless data storage lib: Argument.Heal run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"引数が足りません","color":"white"},{"text":" Heal","color":"red"}]
+# プレイヤー
+    execute if entity @s[type=player] run function api:heal/core/player
+# non-プレイヤー
+    execute if entity @s[type=#lib:living,type=!player,tag=!Uninterferable] run function api:heal/core/non-player

--- a/TheSkyBlessing/data/api/functions/heal/core/modifier.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/modifier.mcfunction
@@ -12,12 +12,12 @@
 # ユーザーストレージ呼び出し
     function oh_my_dat:please
 # 必要なデータ取得
-    execute store result score $Heal Temporary run data get storage lib: Argument.Heal 100
+    execute store result score $Heal Temporary run data get storage api: Argument.Heal 100
     execute store result score $Modifier Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.Heal 100
 # 補正
     scoreboard players operation $Heal Temporary *= $Modifier Temporary
 # 代入
-    execute store result storage lib: Argument.Heal float 0.0001 run scoreboard players get $Heal Temporary
+    execute store result storage api: Argument.Heal float 0.0001 run scoreboard players get $Heal Temporary
 # リセット
     scoreboard players reset $Heal Temporary
     scoreboard players reset $Modifier Temporary

--- a/TheSkyBlessing/data/api/functions/heal/core/modifier.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/modifier.mcfunction
@@ -1,8 +1,8 @@
-#> lib:heal/core/modifier
+#> api:heal/core/modifier
 #
 # 回復量に補正をかける
 #
-# @within function lib:heal/modifier
+# @within function api:heal/modifier
 
 #> Temp
 # @private

--- a/TheSkyBlessing/data/api/functions/heal/core/non-player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/non-player.mcfunction
@@ -19,10 +19,10 @@
     scoreboard players operation $MaxHealth Temporary *= $100 Const
     execute store result score $MaxHealthMultiplier Temporary run function api:mob/get_max_health_multiplier
 # 代入
-    execute store result score $Heal Temporary run data get storage lib: Argument.Heal 100
+    execute store result score $Heal Temporary run data get storage api: Argument.Heal 100
 # マルチ補正
-    execute unless data storage lib: Argument{FixedHeal:true} if score $MaxHealthMultiplier Temporary matches 1.. run scoreboard players operation $Heal Temporary *= $MaxHealthMultiplier Temporary
-    execute unless data storage lib: Argument{FixedHeal:true} run scoreboard players operation $Heal Temporary /= $10 Const
+    execute unless data storage api: Argument{FixedHeal:true} if score $MaxHealthMultiplier Temporary matches 1.. run scoreboard players operation $Heal Temporary *= $MaxHealthMultiplier Temporary
+    execute unless data storage api: Argument{FixedHeal:true} run scoreboard players operation $Heal Temporary /= $10 Const
 # 減算
     scoreboard players operation $Health Temporary += $Heal Temporary
 # 最大体力チェック

--- a/TheSkyBlessing/data/api/functions/heal/core/non-player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/non-player.mcfunction
@@ -1,8 +1,8 @@
-#> lib:heal/core/non-player
+#> api:heal/core/non-player
 #
 # プレイヤー以外に対する処理
 #
-# @within function lib:heal/
+# @within function api:heal/
 
 #> Private
 # @private

--- a/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
@@ -9,11 +9,11 @@
     #declare score_holder $Fluctuation
 
 # 負数の場合の処理
-    execute store result score $Fluctuation Temporary run data get storage lib: Argument.Heal
-    execute if score $Fluctuation Temporary matches ..-1 run data modify storage lib: Argument.Heal set value 0
+    execute store result score $Fluctuation Temporary run data get storage api: Argument.Heal
+    execute if score $Fluctuation Temporary matches ..-1 run data modify storage api: Argument.Heal set value 0
 # リセット
     scoreboard players reset $Fluctuation Temporary
 # 代入
-    data modify storage api: Argument.Fluctuation set from storage lib: Argument.Heal
+    data modify storage api: Argument.Fluctuation set from storage api: Argument.Heal
 # Healthを持つEntityであれば実行
     function lib:score_to_health_wrapper/fluctuation

--- a/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
@@ -1,8 +1,8 @@
-#> lib:heal/core/player
+#> api:heal/core/player
 #
 # プレイヤーに対する処理
 #
-# @within function lib:heal/
+# @within function api:heal/
 
 #> Private
 # @private

--- a/TheSkyBlessing/data/api/functions/heal/modifier.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/modifier.mcfunction
@@ -1,12 +1,12 @@
-#> lib:heal/modifier
+#> api:heal/modifier
 #
 # ヒールライブラリの引数を実行者の補正値で補正します
 #
-# @deprecated change to `api:heal/modifier`
 # @input
 #   as entity
 #   storage lib: Argument.Heal : float
 # @output storage lib: Argument.Heal : float
 # @api
 
-function api:heal/modifier
+# 補正
+    execute if entity @s[type=player] run function api:heal/core/modifier

--- a/TheSkyBlessing/data/api/functions/heal/modifier.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/modifier.mcfunction
@@ -4,8 +4,8 @@
 #
 # @input
 #   as entity
-#   storage lib: Argument.Heal : float
-# @output storage lib: Argument.Heal : float
+#   storage api: Argument.Heal : float
+# @output storage api: Argument.Heal : float
 # @api
 
 # 補正

--- a/TheSkyBlessing/data/api/functions/heal/reset.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/reset.mcfunction
@@ -4,5 +4,5 @@
 #
 # @api
 
-data remove storage lib: Argument.Heal
-data remove storage lib: Argument.FixedHeal
+data remove storage api: Argument.Heal
+data remove storage api: Argument.FixedHeal

--- a/TheSkyBlessing/data/api/functions/heal/reset.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/reset.mcfunction
@@ -1,0 +1,8 @@
+#> api:heal/reset
+#
+# api:healの引数をリセットします
+#
+# @api
+
+data remove storage lib: Argument.Heal
+data remove storage lib: Argument.FixedHeal

--- a/TheSkyBlessing/data/lib/functions/heal/.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/heal/.mcfunction
@@ -4,15 +4,11 @@
 #
 # 実行者はHealthを持つEntityである必要があります。
 #
+# @deprecated change to `api:heal/`
 # @input
 #   as player
 #   storage lib: Argument.Heal : float
 #   storage lib: Argument.FixedHeal? : boolean(default: false)
 # @api
 
-# 引数チェック
-    execute unless data storage lib: Argument.Heal run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"引数が足りません","color":"white"},{"text":" Heal","color":"red"}]
-# プレイヤー
-    execute if entity @s[type=player] run function lib:heal/core/player
-# non-プレイヤー
-    execute if entity @s[type=#lib:living,type=!player,tag=!Uninterferable] run function lib:heal/core/non-player
+function api:heal/

--- a/TheSkyBlessing/data/lib/functions/heal/.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/heal/.mcfunction
@@ -11,4 +11,7 @@
 #   storage lib: Argument.FixedHeal? : boolean(default: false)
 # @api
 
+data modify storage api: Argument.Heal set from storage lib: Argument.Heal
+data modify storage api: Argument.FixedHeal set from storage lib: Argument.FixedHeal
+
 function api:heal/

--- a/TheSkyBlessing/data/lib/functions/heal/.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/heal/.mcfunction
@@ -6,7 +6,7 @@
 #
 # @deprecated change to `api:heal/`
 # @input
-#   as player
+#   as living entity
 #   storage lib: Argument.Heal : float
 #   storage lib: Argument.FixedHeal? : boolean(default: false)
 # @api

--- a/TheSkyBlessing/data/lib/functions/heal/modifier.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/heal/modifier.mcfunction
@@ -9,4 +9,6 @@
 # @output storage lib: Argument.Heal : float
 # @api
 
+data modify storage api: Argument.Heal set from storage lib: Argument.Heal
+
 function api:heal/modifier

--- a/TheSkyBlessing/data/lib/functions/heal/reset.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/heal/reset.mcfunction
@@ -5,4 +5,7 @@
 # @deprecated change to `api:heal/reset`
 # @api
 
+data remove storage lib: Argument.Heal
+data remove storage lib: Argument.FixedHeal
+
 function api:heal/reset

--- a/TheSkyBlessing/data/lib/functions/heal/reset.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/heal/reset.mcfunction
@@ -2,7 +2,7 @@
 #
 # lib:healの引数をリセットします
 #
+# @deprecated change to `api:heal/reset`
 # @api
 
-data remove storage lib: Argument.Heal
-data remove storage lib: Argument.FixedHeal
+function api:heal/reset

--- a/TheSkyBlessing/data/lib/functions/status_log/show_health.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/status_log/show_health.mcfunction
@@ -4,7 +4,7 @@
 #
 # @within function
 #   api:damage/core/health_subtract/non-player
-#   lib:heal/core/non-player
+#   api:heal/core/non-player
 #   lib:score_to_health_wrapper/fluctuation
 #   player_manager:vanilla_attack/show_log
 


### PR DESCRIPTION
`lib:heal/*`はDeprecatedに指定、v0.2.Xの開発を終えた時点で削除します。

Related #1215