### PR TITLE
📝 赤い騎士の剣のコマンドとIMP-Docが一致していないのを修正

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0364.red_knights_sword/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0364.red_knights_sword/trigger/3.main.mcfunction
@@ -35,7 +35,7 @@
 
 
 # ダメージ設定
-    # 与えるダメージ = 800
+    # 与えるダメージ = 900
         data modify storage lib: Argument.Damage set value 900f
     # 第一属性
         data modify storage lib: Argument.AttackType set value "Physical"
@@ -43,7 +43,7 @@
         function lib:damage/modifier
         execute as @e[type=#lib:living,type=!player,tag=Victim,distance=..10] run function lib:damage/
 
-# 自身の最大体力の5%分のダメージを与える
+# 自身に5の防御貫通ダメージを与える
     # ダメージ量
         data modify storage lib: Argument.Damage set value 5.0f
     # 第一属性


### PR DESCRIPTION
[![lint-datapack](https://github.com/haiiro2gou/TheSkyBlessing/actions/workflows/datapack-linter.yml/badge.svg?branch=fix%2Fhaiiro_364)](https://github.com/haiiro2gou/TheSkyBlessing/actions/workflows/datapack-linter.yml)