### PR TITLE
🐛 デスログが反映されなかったのを修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/damage/core/health_subtract/player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/health_subtract/player.mcfunction
@@ -9,8 +9,6 @@
     execute store result storage api: Argument.Attacker int 1 run scoreboard players get $LatestModifiedEntity MobUUID
     data modify storage api: Argument.AttackType set from storage api: Argument.AttackType
     data modify storage api: Argument.ElementType set from storage api: Argument.ElementType
-    data remove storage api: Argument.DeathMessage
-    execute if data storage api: Argument.DeathMessage run data modify storage api: Argument.DeathMessage set from storage api: Argument.DeathMessage
 # 体力の減少を反映させる
     function lib:score_to_health_wrapper/fluctuation
 # onAttackのトリガー


### PR DESCRIPTION
何故かapi: Argument.DeathMessageを削除してからやっていたのが原因
それに加え
api: Argument.DeathMessage から
api: Argument.DeathMessage に代入するということも行っていたのでそれも削除