### PR TITLE
島12のテレポーターと神器の位置を、落下しない程度の位置に変更

### DIFF
--- a/Asset/data/asset/functions/island/12/register/.mcfunction
+++ b/Asset/data/asset/functions/island/12/register/.mcfunction
@@ -4,4 +4,4 @@
 #
 # @within tag/function asset:island/register
 
-execute unless data storage asset:island DPR[{D:overworld,X:82,Y:9,Z:14}] in overworld positioned 82 9 14 if entity @p[predicate=api:is_completed_player_chunk_load_waiting_time,distance=..80] run function asset:island/12/register/register
+execute unless data storage asset:island DPR[{D:overworld,X:83,Y:9,Z:8}] in overworld positioned 83 9 8 if entity @p[predicate=api:is_completed_player_chunk_load_waiting_time,distance=..80] run function asset:island/12/register/register

--- a/Asset/data/asset/functions/island/12/register/register.mcfunction
+++ b/Asset/data/asset/functions/island/12/register/register.mcfunction
@@ -6,13 +6,13 @@
 
 
 # 重複防止レジストリへの登録
-    data modify storage asset:island DPR append value {D:overworld,X:82,Y:9,Z:14}
+    data modify storage asset:island DPR append value {D:overworld,X:83,Y:9,Z:8}
 
 # ID (int)
     data modify storage asset:island ID set value 12
 # Rotation (float)
-    data modify storage asset:island Rotation set value 0f
+    data modify storage asset:island Rotation set value 90.0f
 # BOSS ID (int) (Optional)
-    # data modify storage asset:island BossID set value 
+    # data modify storage asset:island BossID set value
 
 function asset:island/common/register

--- a/Asset/data/asset/functions/teleporter/012/.mcfunction
+++ b/Asset/data/asset/functions/teleporter/012/.mcfunction
@@ -4,4 +4,4 @@
 #
 # @within tag/function asset:teleporter/register
 
-execute unless data storage asset:teleporter DPR[{D:overworld,X:82,Y:9,Z:16}] in overworld positioned 82 9 16 if entity @p[predicate=api:is_completed_player_chunk_load_waiting_time,distance=..80] run function asset:teleporter/012/register
+execute unless data storage asset:teleporter DPR[{D:overworld,X:81,Y:9,Z:8}] in overworld positioned 81 9 8 if entity @p[predicate=api:is_completed_player_chunk_load_waiting_time,distance=..80] run function asset:teleporter/012/register

--- a/Asset/data/asset/functions/teleporter/012/register.mcfunction
+++ b/Asset/data/asset/functions/teleporter/012/register.mcfunction
@@ -6,7 +6,7 @@
 
 
 # 重複防止レジストリへの登録
-    data modify storage asset:teleporter DPR append value {D:overworld,X:82,Y:9,Z:16}
+    data modify storage asset:teleporter DPR append value {D:overworld,X:81,Y:9,Z:8}
 
 # ID (int)
     data modify storage asset:teleporter ID set value 12


### PR DESCRIPTION
・テレポーター使ったら落ちた、って報告を受けるたびに思い出して、そのたびに忘れていたので今度こそ。
・登録周りを見た感じ、変更するべきはここだけ…だと思ったんですが、足りなかったらごめんなさい
![2022-12-18_08 15 54](https://user-images.githubusercontent.com/46894504/208269503-eab112fc-541c-401f-80a6-ca5db989d1cb.png)
