### PR TITLE
🐛 Mobの乗り物を破壊するTagでチェスト付きボートが破壊されなかったバグを修正

### DIFF
--- a/TheSkyBlessing/data/asset_manager/functions/mob/common_tag/break_rides.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/mob/common_tag/break_rides.mcfunction
@@ -10,6 +10,7 @@
 
     # ボート
         execute if entity @e[type=boat,distance=..1,sort=nearest,limit=1] run playsound minecraft:entity.zombie.attack_wooden_door hostile @a ~ ~ ~ 1 1.2
+        execute if entity @e[type=chest_boat,distance=..1,sort=nearest,limit=1] run playsound minecraft:entity.zombie.attack_wooden_door hostile @a ~ ~ ~ 1 1.2
 
     # 共通パーティクル
         particle minecraft:crit ~ ~1 ~ 0.2 0.2 0.2 1 10


### PR DESCRIPTION
多分このTag実装後に1.19が来たのが原因かも？