### PR TITLE
:construction_worker: ワークフローを並列に動作しないように修正

### DIFF
--- a/.github/workflows/datapack-linter.yml
+++ b/.github/workflows/datapack-linter.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     name: lint

--- a/.github/workflows/datapack-linter.yml
+++ b/.github/workflows/datapack-linter.yml
@@ -10,7 +10,6 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/datapack-linter.yml
+++ b/.github/workflows/datapack-linter.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
   lint:


### PR DESCRIPTION
各ブランチの各イベントで同時に一つしか動きません。
動作途中に新たに push された場合は過去のものがキャンセルされ、新しく動き出します。