### PR TITLE
1.20.2環境下にて耐性エフェクトの数値が取れないバグを修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/damage/core/get_status/get_resistance_lv.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/get_status/get_resistance_lv.mcfunction
@@ -8,11 +8,11 @@
     execute if entity @s[type=player] run function api:data_get/active_effects
     execute if entity @s[type=!player] run data modify storage api: active_effects set from entity @s active_effects
 # 耐性lv(0-indexed)の取得
-    execute store result score $Resistance Temporary run data get storage api: active_effects[{id:"resistance"}].amplifier
-    execute unless data storage api: active_effects[{id:"resistance"}].amplifier run scoreboard players set $Resistance Temporary -1
+    execute store result score $Resistance Temporary run data get storage api: active_effects[{id:"minecraft:resistance"}].amplifier
+    execute unless data storage api: active_effects[{id:"minecraft:resistance"}].amplifier run scoreboard players set $Resistance Temporary -1
 # 127lv(0-indexed)の場合、lib:damageの演出用に付与されているものなので、HiddenEffectを再度参照する
-    execute if score $Resistance Temporary matches 127 unless data storage api: active_effects[{id:"resistance"}].hidden_effect run scoreboard players set $Resistance Temporary -1
-    execute if score $Resistance Temporary matches 127 store result score $Resistance Temporary run data get storage api: active_effects[{id:"resistance"}].hidden_effect.amplifier
+    execute if score $Resistance Temporary matches 127 unless data storage api: active_effects[{id:"minecraft:resistance"}].hidden_effect run scoreboard players set $Resistance Temporary -1
+    execute if score $Resistance Temporary matches 127 store result score $Resistance Temporary run data get storage api: active_effects[{id:"minecraft:resistance"}].hidden_effect.amplifier
 # 0-indexed -> 1-indexed
     scoreboard players add $Resistance Temporary 1
 # リセット


### PR DESCRIPTION
minecraft:をつけることで取得可能となる