### PR TITLE
:adhesive_bandage: Return.Summonedを念のため削除する

### DIFF
--- a/TheSkyBlessing/data/api/functions/mob/core/summon.mcfunction
+++ b/TheSkyBlessing/data/api/functions/mob/core/summon.mcfunction
@@ -7,6 +7,9 @@
 # 既存にasset:context idが存在する場合に備えて退避させる
     function asset_manager:common/context_id/stash
 
+# 念のためリセット
+    data remove storage asset:mob Return.Summoned
+
 # ID
     data modify storage asset:context id set from storage api: Argument.ID
 


### PR DESCRIPTION
デバッグ以外では起こらないバグではある

---
mob召喚のfunctionを直で叩いた後にapi経由で召喚すると`asset:mob Return.Summoned`が消えないため一回召喚に失敗するバグの修正