### PR TITLE
HealAPIの修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
@@ -13,10 +13,10 @@
     execute if score $Fluctuation Temporary matches ..-1 run data modify storage api: Argument.Heal set value 0
 # リセット
     scoreboard players reset $Fluctuation Temporary
-# 被回復量補正を掛ける
-    execute unless data storage api: Argument{FixedHeal:true} run function api:heal/core/receive_modifier
 # 代入
     data modify storage api: Argument.Fluctuation set from storage api: Argument.Heal
+# 被回復量補正を掛ける
+    execute unless data storage api: Argument{FixedHeal:true} run function api:heal/core/receive_modifier
 # Healthを持つEntityであれば実行
     function lib:score_to_health_wrapper/fluctuation
 # onHealのトリガー

--- a/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/player.mcfunction
@@ -14,7 +14,7 @@
 # リセット
     scoreboard players reset $Fluctuation Temporary
 # 被回復量補正を掛ける
-    execute unless data storage lib: Argument{FixedHeal:true} run function api:heal/core/receive_modifier
+    execute unless data storage api: Argument{FixedHeal:true} run function api:heal/core/receive_modifier
 # 代入
     data modify storage api: Argument.Fluctuation set from storage api: Argument.Heal
 # Healthを持つEntityであれば実行

--- a/TheSkyBlessing/data/api/functions/heal/core/receive_modifier.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/receive_modifier.mcfunction
@@ -12,12 +12,12 @@
 # ユーザーストレージ呼び出し
     function oh_my_dat:please
 # 必要なデータ取得
-    execute store result score $Heal Temporary run data get storage api: Argument.Heal 100
+    execute store result score $Heal Temporary run data get storage api: Argument.Fluctuation 100
     execute store result score $Modifier Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Modifiers.ReceiveHeal 100
 # 補正
     scoreboard players operation $Heal Temporary *= $Modifier Temporary
 # 代入
-    execute store result storage api: Argument.Heal float 0.0001 run scoreboard players get $Heal Temporary
+    execute store result storage api: Argument.Fluctuation float 0.0001 run scoreboard players get $Heal Temporary
 # リセット
     scoreboard players reset $Heal Temporary
     scoreboard players reset $Modifier Temporary


### PR DESCRIPTION
Fixed #1503 
・被回復補正を参照する際の条件のミスを修正
・被回復補正をArgument.HealではなくArgument.Fluctuationに乗算するように