### PR TITLE
ObjectAssetのsuper.initの不備を解決

### DIFF
--- a/TheSkyBlessing/data/asset/functions/object/super.init.mcfunction
+++ b/TheSkyBlessing/data/asset/functions/object/super.init.mcfunction
@@ -2,6 +2,6 @@
 #
 #
 #
-# @within function asset:object/*/init
+# @within function asset:object/*/init/
 
 function asset_manager:object/init/call_super_methods/


### PR DESCRIPTION
スラッシュ１個足りないせいで、実際のAssetリポジトリにてasset:object/super.initが呼び出せていませんでした。
ObjectAsset、どうにも問題だらけで申し訳ありません…