### PR TITLE
🚑 ScoreToHealthが体力を固定してしまう問題を修正

### DIFF
--- a/ScoreToHealth/changes.diff
+++ b/ScoreToHealth/changes.diff
@@ -397,7 +397,7 @@
 +execute if score @s ScoreToMaxHealth > $_ ScoreToMaxHealth run attribute @s minecraft:generic.max_health modifier add bab7cdc2-fb6a-47f6-0002-00 "ScoreToMaxHealth" 0.0001 add
 +execute if score @s ScoreToMaxHealth > $_ ScoreToMaxHealth run scoreboard players add $__ ScoreToMaxHealth 0001
 +
-+effect give @s minecraft:instant_health 1 252 true
++effect give @s minecraft:instant_health 1 254 true
 +scoreboard players operation @s STMHBackup = @s ScoreToMaxHealth
 +tag @s add ScoreToHealth.Return
 \ No newline at end of file

--- a/ScoreToHealth/data/score_to_health/functions/modify_max_health.mcfunction
+++ b/ScoreToHealth/data/score_to_health/functions/modify_max_health.mcfunction
@@ -184,6 +184,6 @@ execute if score @s ScoreToMaxHealth <= $_ ScoreToMaxHealth run scoreboard playe
 execute if score @s ScoreToMaxHealth > $_ ScoreToMaxHealth run attribute @s minecraft:generic.max_health modifier add bab7cdc2-fb6a-47f6-0002-00 "ScoreToMaxHealth" 0.0001 add
 execute if score @s ScoreToMaxHealth > $_ ScoreToMaxHealth run scoreboard players add $__ ScoreToMaxHealth 0001
 
-effect give @s minecraft:instant_health 1 252 true
+effect give @s minecraft:instant_health 1 254 true
 scoreboard players operation @s STMHBackup = @s ScoreToMaxHealth
 tag @s add ScoreToHealth.Return


### PR DESCRIPTION
多分想定されてる最大体力を踏み越えるとロックアウトするのが問題なので
回復量を極小にすることで対応してる

…はず