### PR TITLE
🧑‍💻 トリガー関連の改善

### DIFF
--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_events/non-player/attack_and_hurt/push_from_attacker.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_events/non-player/attack_and_hurt/push_from_attacker.mcfunction
@@ -15,12 +15,12 @@
     # Index が同一 (即ち、同一の modifier 後の対象) ではない場合は、新規に追加する
         execute store result score $LastIndex Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Index
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack append value {Type: "api",IsVanilla:false}
-        execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amounts append value -1d
-        execute unless score $LastIndex Temporary = $ModifierIndex Global store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amounts[-1] double 0.01 run scoreboard players get $Damage Temporary
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].AttackType set from storage api: Argument.AttackType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].ElementType set from storage api: Argument.ElementType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Metadata set from storage api: Argument.Metadata
     # 攻撃対象に追加する
+        data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amounts append value -1d
+        execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amounts[-1] double 0.01 run scoreboard players get $Damage Temporary
         data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].To append value -1
         execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].To[-1] int 1 run scoreboard players get $DamagerUUID Temporary
 

--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_events/non-player/attack_and_hurt/push_from_attacker.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_events/non-player/attack_and_hurt/push_from_attacker.mcfunction
@@ -15,7 +15,8 @@
     # Index が同一 (即ち、同一の modifier 後の対象) ではない場合は、新規に追加する
         execute store result score $LastIndex Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Index
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack append value {Type: "api",IsVanilla:false}
-        execute unless score $LastIndex Temporary = $ModifierIndex Global store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amount double 0.01 run scoreboard players get $Damage Temporary
+        execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amounts append value -1d
+        execute unless score $LastIndex Temporary = $ModifierIndex Global store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Amounts[-1] double 0.01 run scoreboard players get $Damage Temporary
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].AttackType set from storage api: Argument.AttackType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].ElementType set from storage api: Argument.ElementType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[-1].Metadata set from storage api: Argument.Metadata

--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_events/player/attack_and_damage/push_from_attacker.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_events/player/attack_and_damage/push_from_attacker.mcfunction
@@ -15,7 +15,8 @@
     # Index が同一 (即ち、同一の modifier 後の対象) ではない場合は、新規に追加する
         execute store result score $LastIndex Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Index
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack append value {Type: "api",IsVanilla:false}
-        execute unless score $LastIndex Temporary = $ModifierIndex Global store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amount double 0.0001 run scoreboard players get $Damage Temporary
+        execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts append value -1d
+        execute unless score $LastIndex Temporary = $ModifierIndex Global store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts[-1] double 0.0001 run scoreboard players get $Damage Temporary
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].AttackType set from storage api: Argument.AttackType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].ElementType set from storage api: Argument.ElementType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Metadata set from storage api: Argument.Metadata

--- a/TheSkyBlessing/data/api/functions/damage/core/trigger_events/player/attack_and_damage/push_from_attacker.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/trigger_events/player/attack_and_damage/push_from_attacker.mcfunction
@@ -15,12 +15,12 @@
     # Index が同一 (即ち、同一の modifier 後の対象) ではない場合は、新規に追加する
         execute store result score $LastIndex Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Index
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack append value {Type: "api",IsVanilla:false}
-        execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts append value -1d
-        execute unless score $LastIndex Temporary = $ModifierIndex Global store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts[-1] double 0.0001 run scoreboard players get $Damage Temporary
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].AttackType set from storage api: Argument.AttackType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].ElementType set from storage api: Argument.ElementType
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Metadata set from storage api: Argument.Metadata
     # 攻撃対象に追加する
+        data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts append value -1d
+        execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts[-1] double 0.0001 run scoreboard players get $Damage Temporary
         data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].To append value -1
         execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].To[-1] int 1 run scoreboard players get $DamagerUUID Temporary
 # リセット

--- a/TheSkyBlessing/data/api/functions/heal/core/push_heal_events/healer.mcfunction
+++ b/TheSkyBlessing/data/api/functions/heal/core/push_heal_events/healer.mcfunction
@@ -17,8 +17,9 @@
         execute store result score $LastIndex Temporary run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].Index
         execute unless score $LastIndex Temporary = $ModifierIndex Global run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal append value {}
         execute unless score $LastIndex Temporary = $ModifierIndex Global run execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].Index int 1 run scoreboard players get $ModifierIndex Global
-        execute unless score $LastIndex Temporary = $ModifierIndex Global run execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].Amount double 0.01 run data get storage api: Argument.Fluctuation 100
     # ヒール対象に追加する
+        data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].Amounts append value -1
+        execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].Amounts[-1] double 0.01 run data get storage api: Argument.Fluctuation 100
         data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].To append value -1
         execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Heal[-1].To[-1] int 1 run scoreboard players get $ReceiverUUID Temporary
 

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/attack/add_tag_each_victim.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/attack/add_tag_each_victim.mcfunction
@@ -10,11 +10,11 @@
 # @private
 #declare score_holder $AttackTarget
 
-execute store result score $AttackTarget Temporary run data get storage asset:context Attack.To[-1]
-data remove storage asset:context Attack.To[-1]
+execute store result score $AttackTarget Temporary run data get storage asset:artifact AttackTargets[-1]
+data remove storage asset:artifact AttackTargets[-1]
 
 execute as @e[type=#lib:living,type=!player,distance=..150] if score @s MobUUID = $AttackTarget Temporary run tag @s add Victim
 
 scoreboard players reset $AttackTarget Temporary
 
-execute if data storage asset:context Attack.To[0] run function asset_manager:artifact/triggers/attack/add_tag_each_victim
+execute if data storage asset:artifact AttackTargets[0] run function asset_manager:artifact/triggers/attack/add_tag_each_victim

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/attack/foreach.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/attack/foreach.mcfunction
@@ -8,7 +8,8 @@
     data modify storage asset:context Attack set from storage asset:artifact ArtifactEvents.Attack[-1]
     data remove storage asset:artifact ArtifactEvents.Attack[-1]
 # 攻撃先を取得し、Victim を付与する (null の可能性もある)
-    execute if data storage asset:context Attack.To[0] run function asset_manager:artifact/triggers/attack/add_tag_each_victim
+    data modify storage asset:artifact AttackTargets set from storage asset:context Attack.To
+    execute if data storage asset:artifact AttackTargets[0] run function asset_manager:artifact/triggers/attack/add_tag_each_victim
 # 最大ダメージの計算
     function lib:array/session/open
     data modify storage lib: Array set from storage asset:context Attack.Amounts
@@ -25,6 +26,7 @@
     execute if data storage asset:context Attack{Type:"vanilla_explosion" } run function #asset:artifact/attack/explosion
 # リセット
     data remove storage asset:context Attack
+    data remove storage asset:artifact AttackTargets
     tag @s remove ShouldVanillaAttack
     tag @e[type=#lib:living,type=!player,tag=Victim] remove Victim
 # イベントがまだあれば再帰する

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/attack/foreach.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/attack/foreach.mcfunction
@@ -9,6 +9,12 @@
     data remove storage asset:artifact ArtifactEvents.Attack[-1]
 # 攻撃先を取得し、Victim を付与する (null の可能性もある)
     execute if data storage asset:context Attack.To[0] run function asset_manager:artifact/triggers/attack/add_tag_each_victim
+# 最大ダメージの計算
+    function lib:array/session/open
+    data modify storage lib: Array set from storage asset:context Attack.Amounts
+    function lib:array/math/max
+    data modify storage asset:context Attack.Amount set from storage lib: MaxResult
+    function lib:array/session/close
 # 神器側に受け渡し
     function #asset:artifact/attack
     execute if data storage asset:context Attack{Type:"vanilla_melee"     } run tag @s add ShouldVanillaAttack

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/heal/add_tag_each_receiver.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/heal/add_tag_each_receiver.mcfunction
@@ -10,10 +10,10 @@
 # @private
 #declare score_holder $HealTarget
 
-execute store result score $HealTarget Temporary run data get storage asset:context Heal.To[-1]
-data remove storage asset:context Heal.To[-1]
+execute store result score $HealTarget Temporary run data get storage asset:artifact HealTargets[-1]
+data remove storage asset:artifact HealTargets[-1]
 
 execute as @a if score @s UserID = $HealTarget Temporary run tag @s add Receiver
 
 scoreboard players reset $HealTarget Temporary
-execute if data storage asset:context Heal.To[0] run function asset_manager:artifact/triggers/heal/add_tag_each_receiver
+execute if data storage asset:artifact HealTargets[0] run function asset_manager:artifact/triggers/heal/add_tag_each_receiver

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/heal/foreach.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/heal/foreach.mcfunction
@@ -9,6 +9,12 @@
     data remove storage asset:artifact ArtifactEvents.Heal[-1]
 # ヒール先を取得し、Receiver を付与する (null の可能性もある)
     execute if data storage asset:context Heal.To[0] run function asset_manager:artifact/triggers/heal/add_tag_each_receiver
+# 最大ヒール量の計算
+    function lib:array/session/open
+    data modify storage lib: Array set from storage asset:context Heal.Amounts
+    function lib:array/math/max
+    data modify storage asset:context Heal.Amount set from storage lib: MaxResult
+    function lib:array/session/close
 # 神器側に受け渡し
     function #asset:artifact/heal
 # リセット

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/heal/foreach.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/triggers/heal/foreach.mcfunction
@@ -8,7 +8,8 @@
     data modify storage asset:context Heal set from storage asset:artifact ArtifactEvents.Heal[-1]
     data remove storage asset:artifact ArtifactEvents.Heal[-1]
 # ヒール先を取得し、Receiver を付与する (null の可能性もある)
-    execute if data storage asset:context Heal.To[0] run function asset_manager:artifact/triggers/heal/add_tag_each_receiver
+    data modify storage asset:artifact HealTargets set from storage asset:context Heal.To
+    execute if data storage asset:artifact HealTargets[0] run function asset_manager:artifact/triggers/heal/add_tag_each_receiver
 # 最大ヒール量の計算
     function lib:array/session/open
     data modify storage lib: Array set from storage asset:context Heal.Amounts
@@ -19,6 +20,7 @@
     function #asset:artifact/heal
 # リセット
     data remove storage asset:context Heal
+    data remove storage asset:artifact HealTargets
     tag @a[tag=Receiver] remove Receiver
 # イベントがまだあれば再帰する
     execute if data storage asset:artifact ArtifactEvents.Heal[0] run function asset_manager:artifact/triggers/heal/foreach

--- a/TheSkyBlessing/data/asset_manager/functions/mob/triggers/attack/add_tag_each_victim.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/mob/triggers/attack/add_tag_each_victim.mcfunction
@@ -10,10 +10,10 @@
 # @private
 #declare score_holder $AttackedFrom
 
-execute store result score $AttackedFrom Temporary run data get storage asset:context Attack.To[-1]
-data remove storage asset:context Attack.To[-1]
+execute store result score $AttackedFrom Temporary run data get storage asset:mob AttackTargets[-1]
+data remove storage asset:mob AttackTargets[-1]
 
 execute as @a[distance=..150] if score @s UserID = $AttackedFrom Temporary run tag @s add Victim
 scoreboard players reset $AttackedFrom Temporary
 
-execute if data storage asset:context Attack.To[0] run function asset_manager:mob/triggers/attack/add_tag_each_victim
+execute if data storage asset:mob AttackTargets[0] run function asset_manager:mob/triggers/attack/add_tag_each_victim

--- a/TheSkyBlessing/data/asset_manager/functions/mob/triggers/attack/foreach.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/mob/triggers/attack/foreach.mcfunction
@@ -11,6 +11,12 @@
     data remove storage asset:mob MobEvents.Attack[-1]
 # 攻撃先を取得し、Victim を付与する (null の可能性もある)
     execute if data storage asset:context Attack.To run function asset_manager:mob/triggers/attack/add_tag_each_victim
+# 最大ダメージの計算
+    function lib:array/session/open
+    data modify storage lib: Array set from storage asset:context Attack.Amounts
+    function lib:array/math/max
+    data modify storage asset:context Attack.Amount set from storage lib: MaxResult
+    function lib:array/session/close
 # MOB 側に受け渡し
     function asset_manager:mob/triggers/attack/attempt_call
 # リセット

--- a/TheSkyBlessing/data/asset_manager/functions/mob/triggers/attack/foreach.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/mob/triggers/attack/foreach.mcfunction
@@ -10,7 +10,8 @@
     data modify storage asset:context Attack set from storage asset:mob MobEvents.Attack[-1]
     data remove storage asset:mob MobEvents.Attack[-1]
 # 攻撃先を取得し、Victim を付与する (null の可能性もある)
-    execute if data storage asset:context Attack.To run function asset_manager:mob/triggers/attack/add_tag_each_victim
+    data modify storage asset:mob AttackTargets set from storage asset:context Attack.To
+    execute if data storage asset:mob AttackTargets[0] run function asset_manager:mob/triggers/attack/add_tag_each_victim
 # 最大ダメージの計算
     function lib:array/session/open
     data modify storage lib: Array set from storage asset:context Attack.Amounts
@@ -21,6 +22,7 @@
     function asset_manager:mob/triggers/attack/attempt_call
 # リセット
     data remove storage asset:context Attack
+    data remove storage asset:mob AttackTargets
     tag @p[tag=Victim] remove Victim
 # イベントがまだあれば再帰する
     execute if data storage asset:mob MobEvents.Attack[0] run function asset_manager:mob/triggers/attack/foreach

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/entity_hurt_player/fetch_entity.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/entity_hurt_player/fetch_entity.mcfunction
@@ -34,7 +34,8 @@
     data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Blocked set from storage mob_manager:entity_finder Blocked
     data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].To append value -1
     execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].To[-1] int 1 run scoreboard players get @p[tag=DamagedPlayer] UserID
-    execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amount double 0.01 run scoreboard players get $Damage Temporary
+    data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts append value -1d
+    execute store result storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].MobEvents.Attack[-1].Amounts[-1] double 0.01 run scoreboard players get $Damage Temporary
 
 # リセット
     data remove storage mob_manager:entity_finder Blocked

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/player_hurt_entity/fetch_entity.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/player_hurt_entity/fetch_entity.mcfunction
@@ -22,7 +22,10 @@
 # ArtifactEvents にデータ追加
     data modify storage mob_manager:entity_finder AttackEventData set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[{IsVanilla:true}]
     data remove storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack[{IsVanilla:true}]
-    execute unless data storage mob_manager:entity_finder AttackEventData run function mob_manager:entity_finder/player_hurt_entity/make_attack_event_data
+    execute unless data storage mob_manager:entity_finder AttackEventData run data modify storage mob_manager:entity_finder AttackEventData set value {IsVanilla:true}
+    data modify storage mob_manager:entity_finder AttackEventData.Type set from storage mob_manager:entity_finder DamageType
+    data modify storage mob_manager:entity_finder AttackEventData.Amounts append value -1d
+    execute store result storage mob_manager:entity_finder AttackEventData.Amounts[-1] double 0.01 run scoreboard players get $Damage Temporary
     data modify storage mob_manager:entity_finder AttackEventData.To append value -1
     execute store result storage mob_manager:entity_finder AttackEventData.To[-1] int 1 run scoreboard players get @s MobUUID
     data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ArtifactEvents.Attack append from storage mob_manager:entity_finder AttackEventData

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/player_hurt_entity/make_attack_event_data.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/player_hurt_entity/make_attack_event_data.mcfunction
@@ -1,9 +1,0 @@
-#> mob_manager:entity_finder/player_hurt_entity/make_attack_event_data
-#
-#
-#
-# @within function mob_manager:entity_finder/player_hurt_entity/fetch_entity
-
-data modify storage mob_manager:entity_finder AttackEventData set value {IsVanilla:true}
-data modify storage mob_manager:entity_finder AttackEventData.Type set from storage mob_manager:entity_finder DamageType
-execute store result storage mob_manager:entity_finder AttackEventData.Amount double 0.01 run scoreboard players get $Damage Temporary


### PR DESCRIPTION
- 複数体攻撃/ヒールした際に全ての Amounts が記録され、その最大値が Amount に入るように
- To が失われないように

vanilla attack の範囲攻撃を正しい値にするのは出来るなーとは思ったけど面倒だしまぁ誤差なのでいいかなって感じ。