### PR TITLE
:sparkles: EffectAPI/give で Operation 系を指定できるように

### DIFF
--- a/TheSkyBlessing/data/api/functions/entity/mob/effect/core/give.mcfunction
+++ b/TheSkyBlessing/data/api/functions/entity/mob/effect/core/give.mcfunction
@@ -18,6 +18,8 @@
     execute unless data storage asset:effect Duration run data modify storage asset:effect Duration set from storage api: Argument.Duration
     execute if data storage asset:effect Stack if data storage api: Argument.Stack run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"Effect の Stack が API とデフォルト値の両方で設定されています"}]
     execute unless data storage asset:effect Stack run data modify storage asset:effect Stack set from storage api: Argument.Stack
+    execute unless data storage asset:effect DurationOperation run data modify storage asset:effect DurationOperation set from storage api: Argument.DurationOperation
+    execute unless data storage asset:effect StackOperation run data modify storage asset:effect StackOperation set from storage api: Argument.StackOperation
 # デフォルト値
     execute unless data storage asset:effect Stack run data modify storage asset:effect Stack set value 1
     execute unless data storage asset:effect DurationOperation run data modify storage asset:effect DurationOperation set value "replace"

--- a/TheSkyBlessing/data/api/functions/entity/mob/effect/give.mcfunction
+++ b/TheSkyBlessing/data/api/functions/entity/mob/effect/give.mcfunction
@@ -6,6 +6,8 @@
 #   Argument.ID : int
 #   Argument.Duration? : int (default: Asset | error)
 #   Argument.Stack? : int (default: 1)
+#   Argument.DurationOperation? : "forceReplace" | "replace" | "add" (default: "replace")
+#   Argument.StackOperation? : "forceReplace" | "replace" | "add" (default: "replace")
 #   Argument.FieldOverride? : compound
 # @api
 
@@ -17,4 +19,6 @@
     data remove storage api: Argument.ID
     data remove storage api: Argument.Duration
     data remove storage api: Argument.Stack
+    data remove storage api: Argument.DurationOperation
+    data remove storage api: Argument.StackOperation
     data remove storage api: Argument.FieldOverride


### PR DESCRIPTION
なんでこれなくしたん？？