### PR TITLE
🐛 墓の中身に何も入らないバグを修正

### DIFF
--- a/TheSkyBlessing/data/player_manager/functions/grave/take_items.mcfunction
+++ b/TheSkyBlessing/data/player_manager/functions/grave/take_items.mcfunction
@@ -6,11 +6,13 @@
 #   core:handler/death
 #   player_manager:grave/build/
 
+# EntityStorage呼び出し
+    function oh_my_dat:please
 # IDをIDSetに追加
     execute unless data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LostItems[-1] run data modify storage oh_my_dat: IDSet append value -2147483648
     execute unless data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LostItems[-1] store result storage oh_my_dat: IDSet[-1] int 1 run scoreboard players get @s OhMyDatID
 # Temp -> UserStorage
-    data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LostItems append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].GraveStoreItems
+    data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LostItems append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].GraveStoreItems[]
     data remove storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].GraveStoreItems
 
 # タグ削除


### PR DESCRIPTION
入れ子状になっていたために中身が認識されていなかった