### PR TITLE
🐛 タグ持ちかつ、RespawnEventが80以降ならリスポーン時のイベントを出すように

### DIFF
--- a/TheSkyBlessing/data/core/functions/_index.d.mcfunction
+++ b/TheSkyBlessing/data/core/functions/_index.d.mcfunction
@@ -39,6 +39,7 @@
 #   core:handler/respawn*
 #   asset_manager:effect/*
 #   player_manager:grave/tick/check_with_user
+#   core:tick/player/
     #declare tag InRespawnEvent
 
 #> エリトラ用タグ

--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -24,7 +24,7 @@
     execute if entity @s[scores={FirstJoinEvent=1}] run function core:handler/first_join
     execute if entity @s[scores={RejoinEvent=1..}] run function core:handler/rejoin
     execute if entity @s[scores={RespawnEvent=1}] run function core:handler/respawn
-    execute if entity @s[scores={RespawnEvent=80}] run function core:handler/respawn.delay
+    execute if entity @s[tag=!InRespawnEvent,scores={RespawnEvent=80..}] run function core:handler/respawn.delay
     execute if entity @s[scores={Sneak=1..},predicate=lib:is_sneaking] run function core:handler/sneak
     execute if entity @s[advancements={core:handler/consume_item=true}] run function core:handler/consume_item
     execute if entity @s[advancements={core:handler/attack=true}] run function core:handler/attack

--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -24,7 +24,7 @@
     execute if entity @s[scores={FirstJoinEvent=1}] run function core:handler/first_join
     execute if entity @s[scores={RejoinEvent=1..}] run function core:handler/rejoin
     execute if entity @s[scores={RespawnEvent=1}] run function core:handler/respawn
-    execute if entity @s[tag=!InRespawnEvent,scores={RespawnEvent=80..}] run function core:handler/respawn.delay
+    execute if entity @s[tag=InRespawnEvent,scores={RespawnEvent=80..}] run function core:handler/respawn.delay
     execute if entity @s[scores={Sneak=1..},predicate=lib:is_sneaking] run function core:handler/sneak
     execute if entity @s[advancements={core:handler/consume_item=true}] run function core:handler/consume_item
     execute if entity @s[advancements={core:handler/attack=true}] run function core:handler/attack


### PR DESCRIPTION
- ワールドに入った際にもタグが付与されているのですが、なぜかこれが消えない問題の修正です。根本的な原因は経てていませんが…