### PR TITLE
:children_crossing: RandomLib の内部実装を random コマンドに変更する

### DIFF
--- a/TheSkyBlessing/data/core/functions/define_const.mcfunction
+++ b/TheSkyBlessing/data/core/functions/define_const.mcfunction
@@ -465,8 +465,6 @@ scoreboard players set $536870912 Const 536870912
 scoreboard players set $1073741824 Const 1073741824
 
 #その他定数
-scoreboard players set $31743 Const 31743
-
 scoreboard players set $byte.min Const -256
 scoreboard players set $byte.max Const 255
 scoreboard players set $short.min Const -32768

--- a/TheSkyBlessing/data/core/functions/load_once.mcfunction
+++ b/TheSkyBlessing/data/core/functions/load_once.mcfunction
@@ -124,14 +124,6 @@ team modify NoCollision collisionRule never
     #> 常に値が設定される変数用スコアボード
     # @public
         scoreboard objectives add Global dummy
-    # 乱数値の設定
-        #> Private
-        # @private
-            #declare tag Random
-        summon minecraft:area_effect_cloud ~ ~ ~ {Age:-2147483648,Duration:-1,WaitTime:-2147483648,Tags:["Random"]}
-        execute store result score $Random.Base Global run data get entity @e[tag=Random,limit=1] UUID[1]
-        execute store result score $Random.Carry Global run data get entity @e[tag=Random,limit=1] UUID[3]
-        kill @e[tag=Random,limit=1]
     execute unless score $Difficulty Global matches -2147483648..2147483647 run scoreboard players set $Difficulty Global 1
     scoreboard players set $PurifiedIslands Global 0
     scoreboard players set $TotalIslands Global 60

--- a/TheSkyBlessing/data/lib/functions/random/.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/random/.mcfunction
@@ -1,14 +1,8 @@
 #> lib:random/
 #
-# 0-65534の乱数を返します。
+# 0-65535 の乱数を返します。
 #
 # @output result score uShort
 # @api
 
-scoreboard players operation $Random.Base Global *= $31743 Const
-scoreboard players operation $Random.Base Global += $Random.Carry Global
-scoreboard players operation $Random.Carry Global = $Random.Base Global
-scoreboard players operation $Random.Carry Global /= $65536 Const
-scoreboard players operation $Random.Base Global %= $65536 Const
-
-return run scoreboard players get $Random.Base Global
+return run random value 0..65535

--- a/TheSkyBlessing/data/lib/functions/random/_index.d.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/random/_index.d.mcfunction
@@ -1,9 +1,0 @@
-#> lib:random/_index.d
-# @private
-
-#> rng
-# @within function
-#   lib:random/*
-#   core:load_once
-    #declare score_holder $Random.Base
-    #declare score_holder $Random.Carry


### PR DESCRIPTION
Related #1812