### PR TITLE
:children_crossing: 墓を壊した時にアイテムがばら撒かれないように

### DIFF
--- a/TheSkyBlessing/data/core/functions/handler/first_join.mcfunction
+++ b/TheSkyBlessing/data/core/functions/handler/first_join.mcfunction
@@ -17,7 +17,7 @@
 # お友達(概念)
     tag @s add Friend
 # 無信仰にする
-    function player_manager:god/none/set_tag
+    execute unless predicate player_manager:is_believe/flora unless predicate player_manager:is_believe/nyaptov unless predicate player_manager:is_believe/rumor unless predicate player_manager:is_believe/urban unless predicate player_manager:is_believe/wi-ki run function player_manager:god/none/set_tag
 # ステータス初期化
     data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Attributes.Default set value {Heal:1d,ReceiveHeal:1d,Attack:{Base:1d,Physical:1d,Magic:1d,None:1d,Fire:1d,Water:1d,Thunder:1d},Defense:{Base:1d,Physical:1d,Magic:1d,None:1d,Fire:1d,Water:1d,Thunder:1d},MaxMP:100d,MPRegen:1d,MaxHealth:20d,FallDamage:1d}
     data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Attributes.Value set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Attributes.Default

--- a/TheSkyBlessing/data/player_manager/functions/grave/tick/break.mcfunction
+++ b/TheSkyBlessing/data/player_manager/functions/grave/tick/break.mcfunction
@@ -13,7 +13,7 @@
 # 一回目
     function lib:array/packing_chest
     data modify block 10000 0 10000 Items set from storage lib: Package
-    loot spawn ~ ~1 ~ mine 10000 0 10000 debug_stick
+    loot spawn ~ ~ ~ mine 10000 0 10000 debug_stick
 
 # リセット
     data remove storage lib: Package
@@ -21,8 +21,10 @@
 # 二回目
     function lib:array/packing_chest
     data modify block 10000 0 10000 Items set from storage lib: Package
-    loot spawn ~ ~1 ~ mine 10000 0 10000 debug_stick
+    loot spawn ~ ~ ~ mine 10000 0 10000 debug_stick
 
+# ばら撒いたときのモーションを無くす
+    execute as @e[type=item,distance=..0.5] run function player_manager:grave/tick/stop_motion
 # 壊す
     kill @s
 

--- a/TheSkyBlessing/data/player_manager/functions/grave/tick/stop_motion.mcfunction
+++ b/TheSkyBlessing/data/player_manager/functions/grave/tick/stop_motion.mcfunction
@@ -1,0 +1,12 @@
+#> player_manager:grave/tick/stop_motion
+#
+#
+#
+# @within function player_manager:grave/tick/break
+
+# 吹っ飛び方を弄る
+    data modify entity @s Motion set value [0d,0d,0d]
+# Motionの書き換えが燃やすとなぜか反映される
+    data modify entity @s Fire set value 2s
+# 拾えるまでの時間を調整する
+    data modify entity @s PickupDelay set value 0s


### PR DESCRIPTION
～開発中にストレスの溜まる問題の修正を添えて～