### PR TITLE
:bug: AbsorptionAPI/get で該当 UUID のデータが取得できない時に前のデータが残ってしまう問題を修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/entity/player/absorption/core/get.m.mcfunction
+++ b/TheSkyBlessing/data/api/functions/entity/player/absorption/core/get.m.mcfunction
@@ -2,4 +2,5 @@
 # @input args UUID: [int] @ 4
 # @within function api:entity/player/absorption/get
 
+data remove storage api: Return.Absorption
 $data modify storage api: Return.Absorption set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Absorptions[{UUID:$(UUID)}]


### PR DESCRIPTION
Fix #1815