### PR TITLE
メトリックにArtifact.UsedCountを追加

### DIFF
--- a/TheSkyBlessing/data/metric/functions/artifact.m.mcfunction
+++ b/TheSkyBlessing/data/metric/functions/artifact.m.mcfunction
@@ -9,3 +9,7 @@ data modify storage metric: Artifact.Used[-1].Time set from storage global Time
 
 execute if data storage metric: Artifact.Used[500] run data modify storage metric: Artifact.Used2 set from storage metric: Artifact.Used
 execute if data storage metric: Artifact.Used[500] run data modify storage metric: Artifact.Used set value []
+
+$execute if data storage metric: Artifact.UsedCount.$(ID) store result score $Count Temporary run data get storage metric: Artifact.UsedCount.$(ID)
+$execute store result storage metric: Artifact.UsedCount.$(ID) int 1 run scoreboard players add $Count Temporary 1
+scoreboard players reset $Count Temporary


### PR DESCRIPTION
Artifact.UsedCountに`{神器ID: 使用回数}` の形式で保存
Artifact.Usedのデータが多すぎてRCONで取得できない問題への対応