### PR TITLE
デスログからDeathMessageから"。"を削除

### DIFF
--- a/TheSkyBlessing/data/lib/functions/message/common/die/fire.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/message/common/die/fire.mcfunction
@@ -11,6 +11,6 @@
 execute store result score $Random Temporary run function lib:random/
 scoreboard players operation $Random Temporary %= $3 Const
 
-execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%2$sによって%1$sは燃え尽き真っ白になった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%2$sは%1$sを消し炭にした。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%1$sは%2$sによってロウソクとしてその生涯を終えた。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%2$sによって%1$sは燃え尽き真っ白になった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%2$sは%1$sを消し炭にした","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%1$sは%2$sによってロウソクとしてその生涯を終えた","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]

--- a/TheSkyBlessing/data/lib/functions/message/common/die/magic.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/message/common/die/magic.mcfunction
@@ -11,6 +11,6 @@
 execute store result score $Random Temporary run function lib:random/
 scoreboard players operation $Random Temporary %= $3 Const
 
-execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%1$sは%2$sによって跡形もなく消し飛ばされた。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%1$sは%2$sの魔力に飲まれ死んだ。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%1$sは%2$sの魔力衝撃によって幽体離脱を経験した。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%1$sは%2$sによって跡形もなく消し飛ばされた","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%1$sは%2$sの魔力に飲まれ死んだ","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%1$sは%2$sの魔力衝撃によって幽体離脱を経験した","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]

--- a/TheSkyBlessing/data/lib/functions/message/common/die/physical.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/message/common/die/physical.mcfunction
@@ -12,6 +12,6 @@ execute store result score $Random Temporary run function lib:random/
 scoreboard players operation $Random Temporary %= $100 Const
 
 execute if score $Random Temporary matches 00 run tellraw @a [{"translate": "%2$sの物理的要因によって、%1$sは生命活動の停止を確認... 死んだのだ","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 01..33 run tellraw @a [{"translate": "%1$sは%2$sによって身体を見るも無残な姿と化した。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 34..66 run tellraw @a [{"translate": "%1$sは%2$sに切り裂かれた。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 67..99 run tellraw @a [{"translate": "%1$sは%2$sによって床のシミとなった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 01..33 run tellraw @a [{"translate": "%1$sは%2$sによって身体を見るも無残な姿と化した","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 34..66 run tellraw @a [{"translate": "%1$sは%2$sに切り裂かれた","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 67..99 run tellraw @a [{"translate": "%1$sは%2$sによって床のシミとなった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]

--- a/TheSkyBlessing/data/lib/functions/message/common/die/thunder.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/message/common/die/thunder.mcfunction
@@ -12,6 +12,6 @@ execute store result score $Random Temporary run function lib:random/
 scoreboard players operation $Random Temporary %= $3 Const
 
 
-execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%1$sは%2$sによって電撃に撃たれ目の前が真っ暗になった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%2$sによって%1$sの身体はシビレ、心停止した。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%2$sによってその時%1$sに電流が走る。・・・ひらめきはなかった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%1$sは%2$sによって電撃に撃たれ目の前が真っ暗になった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%2$sによって%1$sの身体はシビレ、心停止した","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%2$sによってその時%1$sに電流が走る・・・ひらめきはなかった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]

--- a/TheSkyBlessing/data/lib/functions/message/common/die/water.mcfunction
+++ b/TheSkyBlessing/data/lib/functions/message/common/die/water.mcfunction
@@ -11,6 +11,6 @@
 execute store result score $Random Temporary run function lib:random/
 scoreboard players operation $Random Temporary %= $3 Const
 
-execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%1$sは%2$sによって真っ青になった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%1$sは%2$sによって冷たくなった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
-execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%2$sによって%1$sはふやけてしまった。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 0 run tellraw @a [{"translate": "%1$sは%2$sによって真っ青になった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 1 run tellraw @a [{"translate": "%1$sは%2$sによって冷たくなった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]
+execute if score $Random Temporary matches 2 run tellraw @a [{"translate": "%2$sによって%1$sはふやけてしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]

--- a/TheSkyBlessing/data/mob_manager/functions/entity_finder/entity_hurt_player/fetch_entity.mcfunction
+++ b/TheSkyBlessing/data/mob_manager/functions/entity_finder/entity_hurt_player/fetch_entity.mcfunction
@@ -24,7 +24,7 @@
 # ScoreToHPFlucに衝撃吸収分だけ加算する
     execute store result storage api: Argument.Fluctuation double -0.1 run scoreboard players get @p[tag=DamagedPlayer] AbsorbedDamage
     execute store result storage api: Argument.Attacker int 1 run scoreboard players get @s MobUUID
-    data modify storage api: Argument.DeathMessage set value ['{"translate":"%1$sは%2$sに倒された。","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}']
+    data modify storage api: Argument.DeathMessage set value ['{"translate":"%1$sは%2$sに倒された","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}']
     data modify storage api: Argument.DisableLog set value true
     execute as @p[tag=DamagedPlayer] at @s run function lib:score_to_health_wrapper/fluctuation
 


### PR DESCRIPTION
理由：バニラのデスログにはついていないため