### PR TITLE
:bug: 削除した Effect の Stack を re-given 時に参照することがある問題を修正

### DIFF
--- a/TheSkyBlessing/data/asset_manager/functions/effect/give/give.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/effect/give/give.mcfunction
@@ -7,7 +7,9 @@
 # エフェクトがすでに付与されている場合はそれを取得する
     function asset_manager:effect/common/try_pop_effect_data
 # 追加するためのデータを加工する
-    function asset_manager:effect/give/make_effect_data
+# エフェクトの削除を行ったときに暫定的に再付与を防止しておく
+    execute if data storage asset:effect TargetEffectData{Duration:-1} run data modify storage asset:effect EffectData set from storage asset:effect TargetEffectData
+    execute unless data storage asset:effect TargetEffectData{Duration:-1} run function asset_manager:effect/give/make_effect_data
 # Effectsに追加(または更新して元に戻す)
     data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Effects append from storage asset:effect EffectData
 # タグ付与


### PR DESCRIPTION
Fix #1849 
make_effect_data 内で stack を -1 として取り扱うという手もある
remove 処理が実行されないことで弊害がどれほど生じるか分からないので一旦こうした