### PR TITLE
⚖️ 暗所ペナルティの発動条件の調整

### DIFF
--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/break.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/break.mcfunction
@@ -1,0 +1,10 @@
+#> world_manager:gimmick/darkness/break
+#
+#
+#
+# @within function world_manager:gimmick/darkness/do
+
+scoreboard players reset $X Temporary
+scoreboard players reset $Y Temporary
+scoreboard players reset $Z Temporary
+data remove storage world_manager:gimmick Darkness.Check

--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/do.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/do.mcfunction
@@ -10,12 +10,13 @@
     execute store result score $X Temporary run random value -48..48
     execute store result score $Y Temporary run random value -16..24
     execute store result score $Z Temporary run random value -48..48
-# プレイヤーの近くは選定しないように
-    execute if score $X Temporary matches -16..16 if score $Y Temporary matches -4..12 if score $Z Temporary matches -16..16 run return run function world_manager:gimmick/darkness/do
 # 座標をストレージに代入
     execute store result storage world_manager:gimmick Darkness.Check.X int 1 run scoreboard players get $X Temporary
     execute store result storage world_manager:gimmick Darkness.Check.Y int 1 run scoreboard players get $Y Temporary
     execute store result storage world_manager:gimmick Darkness.Check.Z int 1 run scoreboard players get $Z Temporary
+# プレイヤーの近くは選定しないように
+    execute if function world_manager:gimmick/darkness/is_player_nearby/ run return run function world_manager:gimmick/darkness/break
+
 # 一時スコアのリセット
     scoreboard players reset $X Temporary
     scoreboard players reset $Y Temporary

--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/is_player_nearby/.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/is_player_nearby/.mcfunction
@@ -1,0 +1,9 @@
+#> world_manager:gimmick/darkness/is_player_nearby/
+#
+#
+#
+# @input storage world_manager:gimmick Darkness.Check: {X: int, Y: int, Z: int}
+# @output args IsPlayerNearby: boolean
+# @within function world_manager:gimmick/darkness/do
+
+return run function world_manager:gimmick/darkness/is_player_nearby/check.m with storage world_manager:gimmick Darkness.Check

--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/is_player_nearby/check.m.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/is_player_nearby/check.m.mcfunction
@@ -1,0 +1,12 @@
+#> world_manager:gimmick/darkness/is_player_nearby/check.m
+#
+#
+#
+# @input args
+#   X: int
+#   Y: int
+#   Z: int
+# @output args IsPlayerNearby: boolean
+# @within function world_manager:gimmick/darkness/is_player_nearby/
+
+$return run execute positioned ~$(X) ~$(Y) ~$(Z) if entity @a[distance=..8,limit=1]

--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty/.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty/.mcfunction
@@ -9,10 +9,10 @@
     #declare score_holder $EnemyCount
 
 # 近くの敵の数が多い場合はなかったことにする
-    execute store result score $EnemyCount Temporary if entity @e[tag=Enemy,distance=..32,limit=15]
+    execute store result score $EnemyCount Temporary if entity @e[type=#lib:living,type=!player,tag=Enemy,distance=..32,limit=15]
     execute if score $EnemyCount Temporary matches 15 run return run scoreboard players reset $EnemyCount Temporary
 # 近くに天使がいる場合はなかったことにする
-    execute if entity @e[tag=Enemy.Boss,distance=..64,limit=1] run return fail
+    execute if entity @e[type=#lib:living,type=!player,tag=Enemy.Boss,distance=..64,limit=1] run return fail
 
 # 敵を召喚する
 # $SpawnCount = floor( 4 * 0.70~1.00(e2) / e2 )

--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty/.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty/.mcfunction
@@ -11,6 +11,7 @@
 # 近くの敵の数が多い場合はなかったことにする
     execute store result score $EnemyCount Temporary if entity @e[type=#lib:living,type=!player,tag=Enemy,distance=..32,limit=15]
     execute if score $EnemyCount Temporary matches 15 run return run scoreboard players reset $EnemyCount Temporary
+    scoreboard players reset $EnemyCount Temporary
 # 近くに天使がいる場合はなかったことにする
     execute if entity @e[type=#lib:living,type=!player,tag=Enemy.Boss,distance=..64,limit=1] run return fail
 

--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty/.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty/.mcfunction
@@ -4,12 +4,22 @@
 #
 # @within function world_manager:gimmick/darkness/penalty.m
 
+#> private
+# @private
+    #declare score_holder $EnemyCount
+
+# 近くの敵の数が多い場合はなかったことにする
+    execute store result score $EnemyCount Temporary if entity @e[tag=Enemy,distance=..32,limit=15]
+    execute if score $EnemyCount Temporary matches 15 run return run scoreboard players reset $EnemyCount Temporary
+# 近くに天使がいる場合はなかったことにする
+    execute if entity @e[tag=Enemy.Boss,distance=..64,limit=1] run return fail
+
 # 敵を召喚する
-# $SpawnCount = floor( 4 * 0.70~1.30(e2) / e2 )
-    execute store result score $SpawnCount Temporary run random value 70..130
+# $SpawnCount = floor( 4 * 0.70~1.00(e2) / e2 )
+    execute store result score $SpawnCount Temporary run random value 70..100
     scoreboard players operation $SpawnCount Temporary *= $4 Const
     scoreboard players operation $SpawnCount Temporary /= $100 Const
     execute if score $SpawnCount Temporary matches 1.. run function world_manager:gimmick/darkness/penalty/spawn
-    
+
 # リセット
     scoreboard players reset $SpawnCount Temporary


### PR DESCRIPTION
他プレイヤーの近くに敵が湧く事象や、島の攻略において死霊が際限なく湧いて妨害を行う事象が発生したため