### PR TITLE
🐛 神器の使用不可メッセージに関する問題を修正

### DIFF
--- a/TheSkyBlessing/data/asset/functions/artifact/common/give.mcfunction
+++ b/TheSkyBlessing/data/asset/functions/artifact/common/give.mcfunction
@@ -98,7 +98,7 @@
     data remove storage asset:artifact SpecialCooldown
     data remove storage asset:artifact AttackInfo
     data remove storage asset:artifact Equipment
-    data remove storage asset:artifact DisabledFlags
+    data remove storage asset:artifact DisabledFlag
     data remove storage asset:artifact DisableCooldownMessage
     data remove storage asset:artifact DisableMPMessage
     data remove storage asset:artifact DisableBreakSound

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/check/.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/check/.mcfunction
@@ -27,8 +27,8 @@
         tag @s[tag=CheckFailed] remove CheckFailed
     # MP必要量による制限
         execute unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag.Check{MPRequire:true} run function asset_manager:artifact/check/check_mp
-        execute if entity @s[tag=CheckFailed] unless score @s MPLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag{MPMessage:true} run tellraw @s {"text":"MPが足りない！","color":"red"}
-        execute if entity @s[tag=CheckFailed] unless score @s MPLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag{MPMessage:true} run scoreboard players set @s MPLogCD 20
+        execute if entity @s[tag=CheckFailed] unless score @s MPLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag.Check{MPMessage:true} run tellraw @s {"text":"MPが足りない！","color":"red"}
+        execute if entity @s[tag=CheckFailed] unless score @s MPLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag.Check{MPMessage:true} run scoreboard players set @s MPLogCD 20
         execute if entity @s[tag=CheckFailed] run tag @s remove CanUsed
         tag @s[tag=CheckFailed] remove CheckFailed
     # TypeCooldownによる制限

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/check/.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/check/.mcfunction
@@ -41,8 +41,8 @@
         tag @s[tag=CheckFailed] remove CheckFailed
     # LocalCooldownによる制限
         execute unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag.Check{LocalCooldown:true} run function asset_manager:artifact/check/check_local_cooldown/
-        execute if entity @s[tag=CheckFailed] unless score @s LocalCDLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag{CDMessage:true} run tellraw @s {"text":"クールダウンが終わっていません。","color":"red"}
-        execute if entity @s[tag=CheckFailed] unless score @s LocalCDLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag{CDMessage:true} run scoreboard players set @s LocalCDLogCD 20
+        execute if entity @s[tag=CheckFailed] unless score @s LocalCDLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag.Check{CDMessage:true} run tellraw @s {"text":"クールダウンが終わっていません。","color":"red"}
+        execute if entity @s[tag=CheckFailed] unless score @s LocalCDLogCD matches 0.. unless data storage asset:artifact TargetItems[0].tag.TSB.DisabledFlag.Check{CDMessage:true} run scoreboard players set @s LocalCDLogCD 20
         execute if entity @s[tag=CheckFailed] run tag @s remove CanUsed
         tag @s[tag=CheckFailed] remove CheckFailed
 # 条件を満たしてない && 使用回数が存在する && トリガーがitemUse ならば使用回数を減らす


### PR DESCRIPTION
・DisableMPMessage、DisableCooldownMessageがtrueでも関係なく使用不可メッセージが出る
・リセットの際にDisableFlag**s**になっている