### PR TITLE
:sparkles: DamageAPI にシングルダメージセッションの仕組みを作成

### DIFF
--- a/TheSkyBlessing/data/api/functions/damage/core/reset.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/core/reset.mcfunction
@@ -27,4 +27,4 @@ data remove storage api: Argument.Metadata
 scoreboard players reset $LatestModifiedUser UserID
 scoreboard players reset $LatestModifiedEntity MobUUID
 
-function api:mob/apply_to_forward_target/reset_initial_apply.m {Key:"api:damage/"}
+execute unless data storage api: {DamageApiSingleDamageSessionOpened:true} run function api:mob/apply_to_forward_target/reset_initial_apply.m {Key:"api:damage/"}

--- a/TheSkyBlessing/data/api/functions/damage/single_damage_session/close.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/single_damage_session/close.mcfunction
@@ -1,0 +1,11 @@
+#> api:damage/single_damage_session/close
+#
+# シングルダメージセッションを終了します
+#
+# @api
+
+execute if data storage lib: {DamageApiSingleDamageSessionOpened:false} run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"api:damage/ のセッションが正常に開かれていません。","color":"white"}]
+
+data modify storage api: DamageApiSingleDamageSessionOpened set value false
+
+function api:mob/apply_to_forward_target/reset_initial_apply.m {Key:"api:damage/"}

--- a/TheSkyBlessing/data/api/functions/damage/single_damage_session/open.mcfunction
+++ b/TheSkyBlessing/data/api/functions/damage/single_damage_session/open.mcfunction
@@ -1,0 +1,14 @@
+#> api:damage/single_damage_session/open
+#
+# シングルダメージセッションを開始します
+#
+# シングルダメージセッションとは、単一 Entity に対して複数の呼び出しが発生し得ない DamageAPI にて、
+# ExtendedCollision を持つ Entity に複数ヒットしてしまう問題に対処するためのセッションです
+#
+# このセッションが開かれている状態では、ExtendedCollision を持つ Entity に対しては、
+# 最初に与えられた攻撃のみがヒットし、以降は全ての攻撃が無視されるようになります
+#
+# @api
+
+execute if data storage lib: {DamageApiSingleDamageSessionOpened:true} run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"api:damage/ のセッションが正常に閉じられていません。","color":"white"}]
+data modify storage api: DamageApiSingleDamageSessionOpened set value true


### PR DESCRIPTION
Fix #1932