### PR TITLE
:children_crossing: 各種ボタンの手前に空行を追加する

### DIFF
--- a/TheSkyBlessing/data/player_manager/functions/god/change_believe/send_confirm_button.mcfunction
+++ b/TheSkyBlessing/data/player_manager/functions/god/change_believe/send_confirm_button.mcfunction
@@ -6,6 +6,8 @@
 
 function player_manager:god/common/disable_another_believer_in_temple_buttons
 
+tellraw @s {"text":""}
+
 tellraw @s [{"text":"今までに失ったアイテムが消滅しますが、本当に改宗しますか？\n"}]
 
 data modify storage api: Argument.Label set value '"改宗する"'

--- a/TheSkyBlessing/data/player_manager/functions/god/common/send_another_believer_in_temple_buttons.mcfunction
+++ b/TheSkyBlessing/data/player_manager/functions/god/common/send_another_believer_in_temple_buttons.mcfunction
@@ -4,6 +4,8 @@
 #
 # @within function player_manager:god/**
 
+tellraw @s {"text":""}
+
 data modify storage api: Argument.Label set value '"この神を信仰する"'
 data modify storage api: Argument.Key set value "change_believe_request"
 data modify storage api: Argument.Listener set value "player_manager:god/change_believe/on_change_believe_request"

--- a/TheSkyBlessing/data/player_manager/functions/god/common/send_believer_in_temple_menu.mcfunction
+++ b/TheSkyBlessing/data/player_manager/functions/god/common/send_believer_in_temple_menu.mcfunction
@@ -8,6 +8,8 @@
 #   player_manager:god/mercy/on_mercy
 #   player_manager:god/change_believe/change_process/task
 
+tellraw @s {"text":""}
+
 data modify storage api: Argument.Label set value '"供物を調べる"'
 data modify storage api: Argument.Key set value "check_offering"
 data modify storage api: Argument.Listener set value "player_manager:god/mercy/on_check_offering"

--- a/TheSkyBlessing/data/settings/functions/send_open_button.mcfunction
+++ b/TheSkyBlessing/data/settings/functions/send_open_button.mcfunction
@@ -4,6 +4,8 @@
 #
 # @within function world_manager:area/01-00.gate_island
 
+tellraw @s {"text":""}
+
 data modify storage api: Argument.Label set value '"ゲーム設定を開く"'
 data modify storage api: Argument.Key set value "open_settings"
 data modify storage api: Argument.Listener set value "settings:send_setting_menu"

--- a/TheSkyBlessing/data/settings/functions/send_setting_menu.mcfunction
+++ b/TheSkyBlessing/data/settings/functions/send_setting_menu.mcfunction
@@ -7,6 +7,7 @@
 #   settings:resend_setting_menu/as_schedule
 
 # タイトル
+    tellraw @s {"text":""}
     tellraw @s [{"text":"--------- ゲーム設定 ----------"}]
 
 # 難易度 - タイトル/現在の難易度表示


### PR DESCRIPTION
Fix #2032