### PR TITLE
:sparkles: トレーダーのレシピ更新チェックを API として切り出す

### DIFF
--- a/TheSkyBlessing/data/api/functions/trader/schedule_recipe_update_check.mcfunction
+++ b/TheSkyBlessing/data/api/functions/trader/schedule_recipe_update_check.mcfunction
@@ -1,0 +1,7 @@
+#> api:trader/schedule_recipe_update_check
+#
+# トレーダーのレシピ更新チェックをスケジュールします
+#
+# @api
+
+scoreboard players add $TraderRecipeVersion Global 1

--- a/TheSkyBlessing/data/asset_manager/functions/island/dispel/successful.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/island/dispel/successful.mcfunction
@@ -34,4 +34,4 @@
     function asset_manager:island/dispel/dispelled.m with storage asset:island Args
     data remove storage asset:island Args
 # 商人の取引内容を更新する
-    scoreboard players add $TraderRecipeVersion Global 1
+    function api:trader/schedule_recipe_update_check

--- a/TheSkyBlessing/data/asset_manager/functions/trader/_index.d.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/trader/_index.d.mcfunction
@@ -26,9 +26,9 @@
 
 #> trader versioning
 # @within function
+#   api:trader/schedule_recipe_update_check
 #   asset_manager:trader/tick/4_interval
 #   asset_manager:trader/common/update_recipe
-#   asset_manager:island/dispel/successful
 #   core:load_once
     #declare score_holder $TraderRecipeVersion
 


### PR DESCRIPTION
Fix #2060