### PR TITLE
:bug: ForwardTarget を持つ entity に関する EffectAsset の処理が正しくない問題を修正

### DIFF
--- a/TheSkyBlessing/data/api/functions/entity/mob/effect/give.mcfunction
+++ b/TheSkyBlessing/data/api/functions/entity/mob/effect/give.mcfunction
@@ -14,4 +14,5 @@
 # validate
     execute unless data storage api: Argument.ID run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"引数が足りません"},{"text":" ID","color":"red"}]
 # 呼び出し
-    function api:mob/apply_to_forward_target/with_non-idempotent.m {CB:"api:entity/mob/effect/core/give",Key:"api:entity/mob/effect/give",IsForwardedOnly:true}
+    execute if entity @s[type=#lib:living,tag= ExtendedCollision,tag=!Uninterferable,tag=!Death] run return run function api:mob/apply_to_forward_target/with_non-idempotent.m {CB:"api:entity/mob/effect/core/give",Key:"api:entity/mob/effect/give",IsForwardedOnly:true}
+    execute if entity @s[type=#lib:living,tag=!ExtendedCollision,tag=!Uninterferable,tag=!Death] run function api:entity/mob/effect/core/give

--- a/TheSkyBlessing/data/api/functions/entity/mob/effect/remove/from_id.mcfunction
+++ b/TheSkyBlessing/data/api/functions/entity/mob/effect/remove/from_id.mcfunction
@@ -9,4 +9,5 @@
 # validate
     execute unless data storage api: Argument.ID run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"引数が足りません","color":"white"},{"text":" ID","color":"red"}]
 # 呼び出し
-    function api:mob/apply_to_forward_target/with_non-idempotent.m {CB:"api:entity/mob/effect/core/remove/from_id",Key:"api:entity/mob/effect/remove/from_id",IsForwardedOnly:true}
+    execute if entity @s[type=#lib:living,tag= ExtendedCollision,tag=!Uninterferable,tag=!Death] run return run function api:mob/apply_to_forward_target/with_non-idempotent.m {CB:"api:entity/mob/effect/core/remove/from_id",Key:"api:entity/mob/effect/remove/from_id",IsForwardedOnly:true}
+    execute if entity @s[type=#lib:living,tag=!ExtendedCollision,tag=!Uninterferable,tag=!Death] run function api:entity/mob/effect/core/remove/from_id

--- a/TheSkyBlessing/data/api/functions/entity/mob/effect/remove/from_level.mcfunction
+++ b/TheSkyBlessing/data/api/functions/entity/mob/effect/remove/from_level.mcfunction
@@ -13,4 +13,5 @@
     execute unless data storage api: Argument.ClearType run data modify storage api: Argument.ClearType set value "all"
     execute unless data storage api: Argument.ClearCount run data modify storage api: Argument.ClearCount set value 2147483647
 # 呼び出し
-    function api:mob/apply_to_forward_target/with_non-idempotent.m {CB:"api:entity/mob/effect/core/remove/from_level/",Key:"api:entity/mob/effect/remove/from_level",IsForwardedOnly:true}
+    execute if entity @s[type=#lib:living,tag= ExtendedCollision,tag=!Uninterferable,tag=!Death] run return run function api:mob/apply_to_forward_target/with_non-idempotent.m {CB:"api:entity/mob/effect/core/remove/from_level/",Key:"api:entity/mob/effect/remove/from_level",IsForwardedOnly:true}
+    execute if entity @s[type=#lib:living,tag=!ExtendedCollision,tag=!Uninterferable,tag=!Death] run function api:entity/mob/effect/core/remove/from_level/


### PR DESCRIPTION
これはこれとしてヘイローン本体に Uninterferable が付いてるのが原因っぽい