### PR TITLE
🐛エンドゲートウェイでの移動時、落下ダメージを受けることがあるのを修正

### DIFF
--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -43,12 +43,14 @@
     execute if entity @s[scores={DropEvent=1..}] run function core:handler/drop
 # ゲートウェイに重なっていないならタグを付与
     execute if entity @s[gamemode=!spectator] positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway run tag @s add NotInGateway
+# ゲートウェイに入っていたなら、低速落下を付与する
+    execute if entity @s[tag=!NotInGateway] run effect give @s slow_falling 1 0 true
 # エリア処理
     function world_manager:area/
 # トリガー処理
     function player_manager:trigger/
-# ゲートウェイに入っていないなら、落下ダメージの処理
-    execute if entity @s[tag=NotInGateway] run function player_manager:fall_damage/
+# 落下ダメージの処理
+    function player_manager:fall_damage/
 # 神の処理
     function player_manager:god/tick
 # 神器処理

--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -15,6 +15,10 @@
 #   core:handler/attack
     #declare tag this
 
+#> ゲートウェイの検知用
+# @private
+    #declare tag NotInGateway
+
 # thisタグ付与
     tag @s add this
 
@@ -37,12 +41,14 @@
     execute if entity @s[scores={ClickCarrotEvent=1..}] run function core:handler/click.carrot
     execute if entity @s[scores={Elytra=1..}] run function core:handler/flying_elytra
     execute if entity @s[scores={DropEvent=1..}] run function core:handler/drop
+# ゲートウェイに重なっていないならタグを付与
+    execute if entity @s[gamemode=!spectator] positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway run tag @s add NotInGateway
 # エリア処理
     function world_manager:area/
 # トリガー処理
     function player_manager:trigger/
-# 落下ダメージの処理
-    function player_manager:fall_damage/
+# ゲートウェイに入っていないなら、落下ダメージの処理
+    execute if entity @s[tag=NotInGateway] run function player_manager:fall_damage/
 # 神の処理
     function player_manager:god/tick
 # 神器処理
@@ -60,3 +66,4 @@
 
 # リセット
     tag @s remove this
+    tag @s remove NotInGateway

--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -43,9 +43,8 @@
     execute if entity @s[scores={DropEvent=1..}] run function core:handler/drop
 # ゲートウェイに重なっていないならタグを付与
     execute if entity @s[gamemode=!spectator] positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway run tag @s add NotInGateway
-# ゲートウェイに入っていたなら、落下処理をスキップする用のタグを付与
+# ゲートウェイに入っていたなら、低速落下を付与
     effect give @s[tag=!NotInGateway] slow_falling 1 0 true
-    tag @s[tag=!NotInGateway] add FallDamageImmunity
 # エリア処理
     function world_manager:area/
 # トリガー処理
@@ -68,5 +67,4 @@
     function player_manager:absorption/
 # リセット
     tag @s remove this
-    tag @s[tag=NotInGateway] remove FallDamageImmunity
     tag @s remove NotInGateway

--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -43,8 +43,8 @@
     execute if entity @s[scores={DropEvent=1..}] run function core:handler/drop
 # ゲートウェイに重なっていないならタグを付与
     execute if entity @s[gamemode=!spectator] positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway run tag @s add NotInGateway
-# ゲートウェイに入っていたなら、低速落下を付与する
-    execute if entity @s[tag=!NotInGateway] run effect give @s slow_falling 1 0 true
+# ゲートウェイに入っていたなら、落下処理をスキップする用のタグを付与
+    tag @s[tag=!NotInGateway] add FallDamageImmunity
 # エリア処理
     function world_manager:area/
 # トリガー処理
@@ -65,7 +65,7 @@
     function player_manager:set_team_and_per_health
 # 緩衝体力処理
     function player_manager:absorption/
-
 # リセット
     tag @s remove this
     tag @s remove NotInGateway
+    tag @s remove FallDamageImmunity

--- a/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
+++ b/TheSkyBlessing/data/core/functions/tick/player/.mcfunction
@@ -44,6 +44,7 @@
 # ゲートウェイに重なっていないならタグを付与
     execute if entity @s[gamemode=!spectator] positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~0.3 ~0.9 ~0.3 positioned ~0.3 ~0.0 ~0.3 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway positioned ~-.6 ~0.0 ~0.6 unless predicate lib:in_end_gateway positioned ~0.0 ~0.0 ~-.6 unless predicate lib:in_end_gateway run tag @s add NotInGateway
 # ゲートウェイに入っていたなら、落下処理をスキップする用のタグを付与
+    effect give @s[tag=!NotInGateway] slow_falling 1 0 true
     tag @s[tag=!NotInGateway] add FallDamageImmunity
 # エリア処理
     function world_manager:area/
@@ -67,5 +68,5 @@
     function player_manager:absorption/
 # リセット
     tag @s remove this
+    tag @s[tag=NotInGateway] remove FallDamageImmunity
     tag @s remove NotInGateway
-    tag @s remove FallDamageImmunity

--- a/TheSkyBlessing/data/lib/predicates/in_end_gateway.json
+++ b/TheSkyBlessing/data/lib/predicates/in_end_gateway.json
@@ -1,20 +1,15 @@
 {
-  "condition": "minecraft:all_of",
-  "terms": [
-    {
-      "condition": "minecraft:all_of",
-      "terms": [
+    "condition": "minecraft:all_of",
+    "terms": [
         {
-          "condition": "minecraft:location_check",
-          "predicate": {
-            "block": {
-              "blocks": [
-                "minecraft:end_gateway"
-              ]
+            "condition": "minecraft:location_check",
+            "predicate": {
+                "block": {
+                    "blocks": [
+                        "minecraft:end_gateway"
+                    ]
+                }
             }
-          }
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/TheSkyBlessing/data/lib/predicates/in_end_gateway.json
+++ b/TheSkyBlessing/data/lib/predicates/in_end_gateway.json
@@ -1,15 +1,10 @@
 {
-    "condition": "minecraft:all_of",
-    "terms": [
-        {
-            "condition": "minecraft:location_check",
-            "predicate": {
-                "block": {
-                    "blocks": [
-                        "minecraft:end_gateway"
-                    ]
-                }
-            }
+    "condition": "minecraft:location_check",
+    "predicate": {
+        "block": {
+            "blocks": [
+                "minecraft:end_gateway"
+            ]
         }
-    ]
+    }
 }

--- a/TheSkyBlessing/data/lib/predicates/in_end_gateway.json
+++ b/TheSkyBlessing/data/lib/predicates/in_end_gateway.json
@@ -1,0 +1,20 @@
+{
+  "condition": "minecraft:all_of",
+  "terms": [
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:location_check",
+          "predicate": {
+            "block": {
+              "blocks": [
+                "minecraft:end_gateway"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fix #2027 
やってることはシンプルで、溶岩のチェックの処理と同じ方法でゲートウェイに触れてることを検知して、触れてるようなら落下ダメージの処理をスキップするようにしました。

現状、長距離テレポートで落下ダメージを受けるのってエンドゲートウェイだけなんですかね？報告を見る限り、もっぱら神域や練習場への移動で起こるようなので…通常のテレポーターでも起こるようであれば、これとはまた別の対策が必要ですね。