### PR TITLE
:children_crossing: 神器の ｢装備時効果｣ を ｢セット効果｣ に変えられるように

### DIFF
--- a/TheSkyBlessing/data/asset/functions/artifact/example/give/2.give.mcfunction
+++ b/TheSkyBlessing/data/asset/functions/artifact/example/give/2.give.mcfunction
@@ -43,7 +43,7 @@ data modify storage asset:artifact MPCost set value 0
 # data modify storage asset:artifact AttackInfo.IsRangeAttack set value "never"
 # data modify storage asset:artifact AttackInfo.AttackRange set value "?"
 
-data modify storage asset:artifact Equipment.Effects set value [{ID:65535,Visible:true}]
+data modify storage asset:artifact Equipment.Effects set value [{ID:65535,Visible:true,IsSetEffect:true}]
 data modify storage asset:artifact Equipment.Modifiers set value [{Type:"max_health",Amount:4d,Operation:"add"}]
 
 data modify storage asset:artifact CanUsedGod set value "ALL"

--- a/TheSkyBlessing/data/asset_manager/functions/artifact/create/set_lore/equipment/register.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/artifact/create/set_lore/equipment/register.mcfunction
@@ -12,6 +12,9 @@
 
 # 名前をLoreに組み込む
     data modify storage asset:artifact EquipName set from storage asset:effect Name
+    data modify storage asset:artifact EffectTypeName set value "装備時効果"
+    data modify storage asset:artifact IsSetEffect set from storage asset:artifact Equipment.Effects[0].IsSetEffect
+    execute if data storage asset:artifact {IsSetEffect:true} run data modify storage asset:artifact EffectTypeName set value "セット効果"
     loot replace block 10000 0 10000 container.0 loot asset_manager:artifact/generate_lore/equipment
     data modify storage asset:artifact Item.tag.display.Lore append from block 10000 0 10000 Items[0].tag.display.Lore[0]
 # 説明文をLoreに組み込む
@@ -19,6 +22,8 @@
 
 # リセット
     data remove storage asset:artifact EquipName
+    data remove storage asset:artifact EffectTypeName
+    data remove storage asset:artifact IsSetEffect
     data remove storage asset:effect ID
     data remove storage asset:effect Extends
     data remove storage asset:effect Name

--- a/TheSkyBlessing/data/asset_manager/loot_tables/artifact/generate_lore/equipment.json
+++ b/TheSkyBlessing/data/asset_manager/loot_tables/artifact/generate_lore/equipment.json
@@ -19,7 +19,11 @@
                                         "italic": false
                                     },
                                     {
-                                        "text": "装備時効果　"
+                                        "storage": "asset:artifact",
+                                        "nbt": "EffectTypeName"
+                                    },
+                                    {
+                                        "text":"　"
                                     },
                                     {
                                         "text": "\u0006",


### PR DESCRIPTION
Fix #2080