### PR TITLE
:rewind: Revert ":bug: 透明化対策のため、コンテナを一度消してから設置するように"

### DIFF
--- a/TheSkyBlessing/data/asset_manager/functions/container/register/construct/set_container_block.m.mcfunction
+++ b/TheSkyBlessing/data/asset_manager/functions/container/register/construct/set_container_block.m.mcfunction
@@ -6,5 +6,4 @@
 #   Block
 # @within function asset_manager:container/register/construct/
 
-setblock ~ ~ ~ air
 $setblock ~ ~ ~ $(Block)


### PR DESCRIPTION
This reverts commit b1ad7927fd4c35cebfd9a7e94e99aa6b58bd60f2.

なんかこれやったら元々入ってたアイテムがばらまかれるようになった、意味わからん