### PR TITLE
:bug: 暗闇ペナルティでスポーンする mob が地中に埋まることがある問題を修正

### DIFF
--- a/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty.m.mcfunction
+++ b/TheSkyBlessing/data/world_manager/functions/gimmick/darkness/penalty.m.mcfunction
@@ -8,5 +8,5 @@
 #   Z : int
 # @within function world_manager:gimmick/darkness/do
 
-$execute align xyz positioned ~0.5 ~0.5 ~0.5 positioned ~$(X) ~$(Y) ~$(Z) positioned ~ ~-1.5 ~ run function world_manager:gimmick/darkness/penalty/
+$execute align xyz positioned ~0.5 ~0.5 ~0.5 positioned ~$(X) ~$(Y) ~$(Z) positioned ~ ~-0.5 ~ run function world_manager:gimmick/darkness/penalty/
 scoreboard players remove $DarknessAnxiety Global 100


### PR DESCRIPTION
Fix #2048 